### PR TITLE
cli regression improvements

### DIFF
--- a/test/t/2340_service_reload_component.pl
+++ b/test/t/2340_service_reload_component.pl
@@ -24,7 +24,7 @@ my $cmd = qq($homedir/$cli service reload $pgversion);
 print("cmd = $cmd\n");
 my ($stdout_buf)= (run_command_and_exit_iferr ($cmd))[3];
 
-if(contains(@$stdout_buf[0], "reloading"))
+if(contains($stdout_buf->[0], "reloading"))
 {
     exit(0);
 }

--- a/test/t/2360_service_restart_component.pl
+++ b/test/t/2360_service_restart_component.pl
@@ -16,6 +16,7 @@ my $homedir = "$ENV{EDGE_HOME_DIR}";
 my $cli = $ENV{EDGE_CLI};
 my $pgversion = $ENV{EDGE_COMPONENT};
 
+
 #
 # We use nodectl to service restart pg16.
 # 
@@ -25,8 +26,19 @@ print("cmd = $cmd\n");
 my ($stdout_buf)= (run_command_and_exit_iferr ($cmd))[3];
 print("stdout_buf : @$stdout_buf");
 
-# A successfull restart returns two lines, stopping pgV in its line 0 and starting pgV in its line 1
-if(contains(@$stdout_buf[0], "stopping") && contains(@$stdout_buf[1], "starting"))
+# A successfull restart (with pgV running as a systemctl service) it returns the following four lines:
+# pg16 stopping 
+# #sudo systemctl stop pg16 
+# pg16 starting on port 6432
+# #sudo systemctl start pg16
+
+# Combine trimmed lines into a single string as the \n in the output seems to change order of output.
+# map processes each element of @$stdout_buf using the sanitize_and_combine_multiline_stdout function.
+# join combines the processed elements into a single string.
+
+@$stdout_buf = join(' ', map { sanitize_and_combine_multiline_stdout($_) } @$stdout_buf);
+
+if (contains($stdout_buf->[0], "stopping") && contains($stdout_buf->[0], "starting"))
 {
     exit(0);
 }

--- a/test/t/2770_service_enable_error.pl
+++ b/test/t/2770_service_enable_error.pl
@@ -22,11 +22,11 @@ my $cli = $ENV{EDGE_CLI};
 
 my $cmd = qq($homedir/$cli service enable pg10);
 print("cmd = $cmd\n");
-my ($stdout_buf)= (run_command_and_exit_iferr ($cmd))[3];
+my ($stdout_buf)= (run_command($cmd))[3];
 print("stdout_buf = @$stdout_buf\n");
 
 # Check if the command errored out with the expected message
-if (contains(@$stdout_buf[0], "Invalid component parameter"))
+if (contains($stdout_buf->[0], "Invalid component parameter"))
  {
     exit(0);
  }

--- a/test/t/2984_start_service_component.pl
+++ b/test/t/2984_start_service_component.pl
@@ -25,10 +25,10 @@ my $exitcode = 0;
 my $cmd0 = qq($homedir/$cli service status $pgversion);
 print("cmd = $cmd0\n");
 my ($stdout_buf)= (run_command_and_exit_iferr ($cmd0))[3];
-print("stdout_buf : @$stdout_buf");
+print("stdout_buf : @$stdout_buf \n");
 
 # If server is stopped, we attempt to service start it
-if (contains(@$stdout_buf[0], "stopped on port"))
+if (contains($stdout_buf->[0], "stopped on port"))
  {
     # service start pgV
     my $cmd = qq($homedir/$cli service start $pgversion);
@@ -36,7 +36,7 @@ if (contains(@$stdout_buf[0], "stopped on port"))
     my ($stdout_buf)= (run_command_and_exit_iferr ($cmd))[3];
     print("stdout_buf : @$stdout_buf");
     # if service start was successful 
-    if(contains(@$stdout_buf[0], "starting on port"))
+    if(contains($stdout_buf->[0], "starting on port"))
     {
         print("$pgversion started successfully. Exiting with success\n");
         $exitcode = 0;

--- a/test/t/2985_stop_service_component.pl
+++ b/test/t/2985_stop_service_component.pl
@@ -27,14 +27,14 @@ my ($stdout_buf0)= (run_command_and_exit_iferr ($cmd0))[3];
 print("stdout_buf0 : @$stdout_buf0");
 
 # If server is running, we attempt to service stop it
-if (contains(@$stdout_buf0[0], "running on port"))
+if (contains($stdout_buf0->[0], "running on port"))
  {
     my $cmd = qq($homedir/$cli service stop $pgversion);
     print("cmd = $cmd\n");
     my ($stdout_buf)= (run_command_and_exit_iferr ($cmd))[3];
     print("stdout_buf : @$stdout_buf");
     # if service stop was successfuly able to stop the server
-    if(contains(@$stdout_buf[0], "stopping"))
+    if(contains($stdout_buf->[0], "stopping"))
     {
         print("$pgversion stopped successfully. Exiting with success");
         $exitcode = 0;

--- a/test/t/2986_status_without_flag.pl
+++ b/test/t/2986_status_without_flag.pl
@@ -26,7 +26,7 @@ my ($stdout_buf)= (run_command_and_exit_iferr ($cmd))[3];
 print("stdout_buf = @$stdout_buf\n");
 
 # Since this case runs after 2984 test case in the schedule, the server is running
-if (contains(@$stdout_buf[0], "$pgversion running on port"))
+if (contains($stdout_buf->[0], "$pgversion running on port"))
  {
     exit(0);
  }

--- a/test/t/2987_enable_service_component.pl
+++ b/test/t/2987_enable_service_component.pl
@@ -41,7 +41,7 @@ $stdout_buf= (run_command_and_exit_iferr ($cmd0))[3];
 print("stdout_buf : @$stdout_buf \n");
  
 # Check if the service disable command above stopped the running service 
-if (contains(@$stdout_buf[0], "disabled"))
+if (contains($stdout_buf->[0], "disabled"))
  {
     # enable the service
     my $cmd = qq($homedir/$cli service enable $pgversion);

--- a/test/t/2988_disable_service_component.pl
+++ b/test/t/2988_disable_service_component.pl
@@ -31,7 +31,7 @@ my ($stdout_buf)= (run_command_and_exit_iferr ($cmd0))[3];
 print("stdout_buf : @$stdout_buf \n");
  
 # Check if the pgV service is running so we can disable it 
-if (contains(@$stdout_buf[0], "running on port"))
+if (contains($stdout_buf->[0], "running on port"))
  {
     # disable the service
     my $cmd = qq($homedir/$cli service disable $pgversion);
@@ -39,7 +39,7 @@ if (contains(@$stdout_buf[0], "running on port"))
     my ($stdout_buf)= (run_command_and_exit_iferr ($cmd))[3];
     print("stdout_buf : @$stdout_buf \n");
     # if service disable was successful, it would have stopping pgV in its stdout buffer 
-    if(contains(@$stdout_buf[0], "stopping"))
+    if(contains($stdout_buf->[0], "stopping"))
     {
         print("$pgversion stopped \n");
         print("Check if service status shows disabled status \n");

--- a/test/t/300_setup_script.pl
+++ b/test/t/300_setup_script.pl
@@ -36,6 +36,9 @@ if (grep { /already installed/i } @$stdout_buf) {
 # initialise cluster (initdb) through init pgV specifying a custom port
 run_command_and_exit_iferr(qq(pgePasswd=$password $homedir/$cli init $pgversion --port=$port));
 
+# Configure pgV to run as a service for service related (enable/disable) tests
+run_command(qq($homedir/$cli config $pgversion --autostart=on));
+
 # Starting pgV server
 run_command_and_exit_iferr(qq($homedir/$cli start $pgversion));
 

--- a/test/t/399_um_breakdown_script.pl
+++ b/test/t/399_um_breakdown_script.pl
@@ -27,7 +27,7 @@ my $cli = $ENV{EDGE_CLI};
 # Then, use nodectl to remove the Postgres installation.
 #
 
-my $cmd = qq($homedir/$cli remove $pgversion);
+my $cmd = qq($homedir/$cli remove $pgversion --rm-data);
 print("cmd = $cmd\n");
 my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
 
@@ -41,23 +41,6 @@ print("success = $success\n");
 print("stdout_buf = @$stdout_buf\n");
 print("stderr_buf = @$stderr_buf\n");
 
-#
-# Then, remove the data directory 
-#
-if(defined($success)){
-    print("Removing the data directory: $datadir \n");
-        if (File::Path::remove_tree($datadir)) {
-            print("Data directory $datadir removed successfully\n");
-        } else {
-            return 1;
-        }
-
-}
-else {
-    print("Unable to : $cmd \n @$full_buf \n");
-    return 1;
-}
-#my $result = system("rm -rf $home");
 
 #
 # Then, we remove the ~/.pgpass file.

--- a/test/t/8000b_install_pgedge_node1.pl
+++ b/test/t/8000b_install_pgedge_node1.pl
@@ -23,17 +23,18 @@ my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g
 my $exitcode = 0;
 
 # Install pgedge
-print("Install pgedge");
-my $out_buf = (run_command_and_exit_iferr(qq($homedir1/$cli install pgedge -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $ENV{EDGE_START_PORT} --pg $ENV{EDGE_INST_VERSION})))[3];
+print("Install pgedge\n");
+chdir("./$homedir1");
+my $out_buf = (run_command_and_exit_iferr(qq(./$cli setup -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $ENV{EDGE_START_PORT} --pg_ver $ENV{EDGE_INST_VERSION})))[3];
 
 # Check if 'already installed' is present in stdout_buf
 if (grep { /already installed/i } @$out_buf) {
     print("pgedge already installed, Exiting. Full Buffer (Install): @$out_buf\n");
-    $exitcode = 1;
+    $exitcode = 0;
 }
 
 #check for pgV
-my $cmd = qq($homedir1/$cli um list);
+my $cmd = qq(./$cli um list);
 print("cmd = $cmd\n");
 my ($success, $error_message, $full_buf, $stdout_buf, $stderr_buf)= IPC::Cmd::run(command => $cmd, verbose => 0);
 #print("stdout : @$full_buf \n");
@@ -44,7 +45,7 @@ if (defined($success) && !is_umlist_component_installed($stdout_buf, "$pgversion
 } 
 
 #check for spock
-my $cmd2 = qq($homedir1/$cli um list);
+my $cmd2 = qq(./$cli um list);
 print("cmd = $cmd2\n");
 my ($success2, $error_message2, $full_buf2, $stdout_buf2, $stderr_buf2)= IPC::Cmd::run(command => $cmd2, verbose => 0);
 #print("stdout : @$full_buf \n");
@@ -54,7 +55,7 @@ if (defined($success2) && !is_umlist_component_installed($stdout_buf2, "$spockve
 } 
 
 #check for snowflake
-my $cmd3 = qq($homedir1/$cli um list);
+my $cmd3 = qq(./$cli um list);
 print("cmd = $cmd3\n");
 my ($success3, $error_message3, $full_buf3, $stdout_buf3, $stderr_buf3)= IPC::Cmd::run(command => $cmd3, verbose => 0);
 #print("stdout : @$full_buf \n");

--- a/test/t/8001b_install_pgedge_node2.pl
+++ b/test/t/8001b_install_pgedge_node2.pl
@@ -25,12 +25,12 @@ my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
 
 # Install pgedge
 print("Install pgedge");
-my $out_buf = (run_command_and_exit_iferr(qq($homedir2/$cli install pgedge -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $myport2 --pg $ENV{EDGE_INST_VERSION})))[3];
+my $out_buf = (run_command_and_exit_iferr(qq($homedir2/$cli setup -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $myport2 --pg_ver $ENV{EDGE_INST_VERSION})))[3];
 
 # Check if 'already installed' is present in stdout_buf
 if (grep { /already installed/i } @$out_buf) {
     print("pgedge already installed, Exiting. Full Buffer (Install): @$out_buf\n");
-    $exitcode = 1;
+    $exitcode = 0;
 }
 
 #check for pgV

--- a/test/t/8002b_install_pgedge_node3.pl
+++ b/test/t/8002b_install_pgedge_node3.pl
@@ -21,16 +21,16 @@ my $snowflakeversion = "snowflake-$pgversion";
 my $spver = $ENV{EDGE_SPOCK} =~ s/\.//r; #removing the . from version so that 3.2 becomes 32
 my $spockversion = "spock$spver-$pgversion"; #forming the spock product name e.g. spock32-pg16
 my $exitcode = 0;
-my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
+my $myport3 = $ENV{'EDGE_START_PORT'} + 2;
 
 # Install pgedge
 print("Install pgedge");
-my $out_buf = (run_command_and_exit_iferr(qq($homedir3/$cli install pgedge -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $myport2 --pg $ENV{EDGE_INST_VERSION})))[3];
+my $out_buf = (run_command_and_exit_iferr(qq($homedir3/$cli setup -U $ENV{EDGE_USERNAME} -P $ENV{EDGE_PASSWORD} -d $ENV{EDGE_DB} -p $myport3 --pg_ver $ENV{EDGE_INST_VERSION})))[3];
 
 # Check if 'already installed' is present in stdout_buf
 if (grep { /already installed/i } @$out_buf) {
     print("pgedge already installed, Exiting. Full Buffer (Install): @$out_buf\n");
-    $exitcode = 1;
+    $exitcode = 0;
 }
 
 #check for pgV

--- a/test/t/8998_env_remove_pgedge_node1.pl
+++ b/test/t/8998_env_remove_pgedge_node1.pl
@@ -31,7 +31,8 @@ my $exitcode = 0;
 
 # Remove pgedge
 print("Removing pgedge on node 1\n");
-run_command_and_exit_iferr(qq($homedir1/$cli remove pgedge --pg $ENV{EDGE_INST_VERSION}));
+run_command_and_exit_iferr(qq($homedir1/$cli remove $pgversion --rm-data));
+#run_command_and_exit_iferr(qq($homedir1/$cli remove pgedge --pg $ENV{EDGE_INST_VERSION}));
 print("Verifying $pgversion , $spver , $spver are removed from node 1\n");
 #check for pgV
 my $cmd = qq($homedir1/$cli um list);
@@ -60,15 +61,6 @@ if (defined($success3) && !is_umlist_component_installed($stdout_buf3, "$snowfla
 {
     $exitcode++;
 } 
-
-# Cleanup. Removing datadir and the pgpass entry done by the 8000 tests
-
-print("Removing the data directory: $datadir1 \n");
-if (File::Path::remove_tree($datadir1)) {
-    print("Data directory $datadir1 removed successfully\n");
-} else {
-    print("Unable to remove Data directory $datadir1\n");
-}
 
 
 # removing the pgpass file that was created in 8000 test

--- a/test/t/8999_env_remove_pgedge_node2.pl
+++ b/test/t/8999_env_remove_pgedge_node2.pl
@@ -31,7 +31,7 @@ my $exitcode = 0;
 
 # Remove pgedge
 print("Removing pgedge on node 2\n");
-run_command_and_exit_iferr(qq($homedir2/$cli remove pgedge --pg $ENV{EDGE_INST_VERSION}));
+run_command_and_exit_iferr(qq($homedir2/$cli remove $pgversion --rm-data));
 print("Verifying $pgversion , $spver , $spver are removed from node 2\n");
 #check for pgV
 my $cmd = qq($homedir2/$cli um list);
@@ -61,14 +61,7 @@ if (defined($success3) && !is_umlist_component_installed($stdout_buf3, "$snowfla
     $exitcode++;
 } 
 
-# Cleanup. Removing datadir and the pgpass entry done by the 8000 tests
 
-print("Removing the data directory: $datadir2 \n");
-if (File::Path::remove_tree($datadir2)) {
-    print("Data directory $datadir2 removed successfully\n");
-} else {
-    print("Unable to remove Data directory $datadir2\n");
-}
 
 # removing the pgpass file that was created in 8000 test
 my $cmd4 = qq(rm ~/.pgpass);

--- a/test/t/8999b_env_remove_pgedge_node3.pl
+++ b/test/t/8999b_env_remove_pgedge_node3.pl
@@ -28,10 +28,9 @@ my $datadir3="$homedir3/data/$pgversion";
 #my $pgpassEntry = "*:*:*:$username:$password";
 my $exitcode = 0;
 
-
 # Remove pgedge
 print("Removing pgedge on node 3\n");
-run_command_and_exit_iferr(qq($homedir3/$cli remove pgedge --pg $ENV{EDGE_INST_VERSION}));
+run_command_and_exit_iferr(qq($homedir3/$cli remove $pgversion --rm-data));
 print("Verifying $pgversion , $spver , $spver are removed from node 3\n");
 #check for pgV
 my $cmd = qq($homedir3/$cli um list);
@@ -61,19 +60,11 @@ if (defined($success3) && !is_umlist_component_installed($stdout_buf3, "$snowfla
     $exitcode++;
 } 
 
-# Cleanup. Removing datadir and the pgpass entry done by the 8000 tests
-
-print("Removing the data directory: $datadir3 \n");
-if (File::Path::remove_tree($datadir3)) {
-    print("Data directory $datadir3 removed successfully\n");
-} else {
-    print("Unable to remove Data directory $datadir3\n");
-}
 
 # removing the pgpass file that was created in 8000 test
-my $cmd4 = qq(rm ~/.pgpass);
-print("cmd = $cmd4\n");
-run_command($cmd4);
+#my $cmd4 = qq(rm ~/.pgpass);
+#print("cmd = $cmd4\n");
+#run_command($cmd4);
 if ($exitcode==3)
 {
     exit (0);

--- a/test/t/lib/contains.pm
+++ b/test/t/lib/contains.pm
@@ -20,8 +20,12 @@
 
 sub contains
 {
+
     my $haystack = shift;
     my $needle = shift ;
+
+        # Trim leading and trailing whitespaces
+    $haystack =~ s/^\s+|\s+$//g;
 
     print("haystack = ($haystack)\n");
     print("needle = ($needle)\n");
@@ -142,7 +146,26 @@ sub get_json_component_attribute_value {
     return -1; # Indicates that either the component or attribute was not found
 }
 
+sub trim {
+    my $str = shift;
+    $str =~ s/^\s+//;   # removes leading whitespaces
+    $str =~ s/\s+$//;   # removes trailing whitespaces
+    return $str;
+}
 
+# The sanitize_and_combine_multiline_stdout subroutine addresses issues with inconsistencies
+# in multi-line command output obtained from cli calls. There are variations in formatting, 
+# leading/trailing whitespaces, and newline characters that can affect the reliability of subsequent
+# string matching. This function:
+#   1. Trims leading and trailing whitespaces from each line of the multiline buffer output.
+#   2. Combines the sanitized lines into a single string.
+
+sub sanitize_and_combine_multiline_stdout {
+    my $str = shift;
+    $str =~ s/^\s+//;   # removes leading whitespaces
+    $str =~ s/\s+$//;   # removes trailing whitespaces
+    return $str;
+}
 
 
 # This 1 at the end is required, even though it looks like an accident :)


### PR DESCRIPTION
- Enhanced service tests to address random failures and introduced a new function for reliable multi-line CLI stdout comparison.
- Refactored 8000 series setup tests, transitioning to the new setup command and adopting the --rm-data option for efficient data directory removal.
- Updated 300 and 399 tests, configuring pgV service and utilizing --rm-data for streamlined data directory removal in service-related tests.