### PR TITLE
Introduced a new schedule for auto-DDL tests.

### DIFF
--- a/test/schedule_files/auto_ddl_schedule
+++ b/test/schedule_files/auto_ddl_schedule
@@ -1,0 +1,42 @@
+##
+# setup scripts
+##
+t/8000a_env_setup_pgedge_node1.pl
+t/8001a_env_setup_pgedge_node2.pl
+t/8000b_install_pgedge_node1.pl
+t/8001b_install_pgedge_node2.pl
+
+##
+# node creation
+##
+t/8051_env_create_node1.pl
+t/8052_env_create_node2.pl
+##
+# sub-create
+##
+t/6000_setup_sub_create_n1n2_n1.pl
+t/6001_setup_sub_create_n2n1_n2.pl
+##
+# enable autoDDL GUCS
+##
+t/6010_setup_autoddl_gucs_on_n1.pl
+t/6011_setup_autoddl_gucs_on_n2.pl
+##
+# autoDDL scripts
+##
+
+##
+# cleanup scripts
+##
+t/6910_teardown_autoddl_gucs_off_n1.pl
+t/6911_teardown_autoddl_gucs_off_n2.pl
+t/8082_env_sub_drop_n1.pl
+t/8083_env_sub_drop_n2.pl
+t/8086_env_node_drop_n1.pl
+t/8087_env_node_drop_n2.pl
+
+##
+# uninstall pgedge
+##
+t/8998_env_remove_pgedge_node1.pl
+t/8999_env_remove_pgedge_node2.pl

--- a/test/t/6000_setup_sub_create_n1n2_n1.pl
+++ b/test/t/6000_setup_sub_create_n1n2_n1.pl
@@ -1,0 +1,36 @@
+# In this step, we create the subscription n1n2 on node 1.
+
+use strict;
+use warnings;
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+use edge;
+
+# Our parameters are:
+
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $n2port = $ENV{'EDGE_START_PORT'} + 1;
+
+print("The home directory of node 1 is $homedir1\n");
+
+# Then, create the subscription on node 1:
+
+my $cmd1 = qq($homedir1/$ENV{EDGE_CLI} spock sub-create sub_n1n2 'host=$ENV{EDGE_HOST} port=$n2port user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+print("cmd1 = $cmd1\n");
+my $stdout_buf= (run_command_and_exit_iferr ($cmd1))[3];
+print("stdout_buf = @$stdout_buf\n");
+
+if(contains(@$stdout_buf, "sub_create"))
+{
+    print("Subscription created successfully\n");
+    exit(0);
+}
+else
+{
+    print("Failed to create subscription\n");
+    exit(1);
+}

--- a/test/t/6001_setup_sub_create_n2n1_n2.pl
+++ b/test/t/6001_setup_sub_create_n2n1_n2.pl
@@ -1,0 +1,36 @@
+# In this step, we create the subscription n2n1 on node 2.
+
+use strict;
+use warnings;
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+use edge;
+
+# Our parameters are:
+
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $n1port = $ENV{'EDGE_START_PORT'};
+
+print("The home directory of node 2 is $homedir2\n");
+
+# Then, create the subscription on node 2:
+
+my $cmd1 = qq($homedir2/$ENV{EDGE_CLI} spock sub-create sub_n2n1 'host=$ENV{EDGE_HOST} port=$n1port user=$ENV{EDGE_REPUSER} dbname=$ENV{EDGE_DB}' $ENV{EDGE_DB});
+print("cmd1 = $cmd1\n");
+my $stdout_buf= (run_command_and_exit_iferr ($cmd1))[3];
+print("stdout_buf = @$stdout_buf\n");
+
+if(contains(@$stdout_buf, "sub_create"))
+{
+    print("Subscription created successfully\n");
+    exit(0);
+}
+else
+{
+    print("Failed to create subscription\n");
+    exit(1);
+}

--- a/test/t/6010_setup_autoddl_gucs_on_n1.pl
+++ b/test/t/6010_setup_autoddl_gucs_on_n1.pl
@@ -1,0 +1,52 @@
+# This testcase enables the the two primary auto ddl gucs 
+# spock.enable_ddl_replication AND spock.include_ddl_repset
+# on node 1 and performs a reload.
+#
+use strict;
+use warnings;
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+use edge;
+
+# Our parameters are:
+
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $host = $ENV{EDGE_HOST};
+my $port = $ENV{EDGE_START_PORT};
+my $database = $ENV{EDGE_DB};
+print("The home directory of node 1 is $homedir1\n");
+
+# command to enable spock.enable_ddl_replication 
+my $enableDDLRep = qq(alter system set spock.enable_ddl_replication = on);
+# command to enable spock.include_ddl_repset
+my $includeDDLRep = qq(alter system set spock.include_ddl_repset = on);
+# execute the two alter syste commands followed by a server reload
+# all commands cannot be combined in a single -c switch
+my $cmd1 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $host -p $port -d $database -c "$enableDDLRep" -c "$includeDDLRep" -c "select pg_reload_conf()");
+print("cmd1 = $cmd1\n");
+my $stdout_buf= (run_command_and_exit_iferr ($cmd1))[3];
+print("stdout_buf = @$stdout_buf\n");
+sleep(0.5); #for the reload to be ready
+
+# Validate the two gucs are ON
+my $cmd2 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $host -p $port -d $database -c "show spock.enable_ddl_replication" -c "show spock.include_ddl_repset");
+print("cmd2 = $cmd2\n");
+my $stdout_buf1= (run_command_and_exit_iferr ($cmd2))[3];
+#combining a multi line output into a single line to ensure consistent comparisons to avoid random \n messing up comparisons
+@$stdout_buf1 = join(' ', map { sanitize_and_combine_multiline_stdout($_) } @$stdout_buf1);
+print("stdout_buf1 = @$stdout_buf1\n");
+
+if (contains($stdout_buf1->[0], "on on"))
+{
+    print("AutoDDL Gucs spock.enable_ddl_replication and spock.include_ddl_repset are now enabled");
+    exit(0);
+}
+else
+{
+    print("AutoDDL Gucs spock.enable_ddl_replication and spock.include_ddl_repset are NOT enabled. Exiting with failure");
+    exit(1);
+}

--- a/test/t/6011_setup_autoddl_gucs_on_n2.pl
+++ b/test/t/6011_setup_autoddl_gucs_on_n2.pl
@@ -1,0 +1,52 @@
+# This testcase enables the the two primary auto ddl gucs 
+# spock.enable_ddl_replication AND spock.include_ddl_repset
+# on node 2 and performs a reload.
+#
+use strict;
+use warnings;
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+use edge;
+
+# Our parameters are:
+
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $host = $ENV{EDGE_HOST};
+my $port = $ENV{'EDGE_START_PORT'} + 1;
+my $database = $ENV{EDGE_DB};
+print("The home directory of node 2 is $homedir2\n");
+
+# command to enable spock.enable_ddl_replication 
+my $enableDDLRep = qq(alter system set spock.enable_ddl_replication = on);
+# command to enable spock.include_ddl_repset
+my $includeDDLRep = qq(alter system set spock.include_ddl_repset = on);
+# execute the two alter syste commands followed by a server reload
+# all commands cannot be combined in a single -c switch
+my $cmd1 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $host -p $port -d $database -c "$enableDDLRep" -c "$includeDDLRep" -c "select pg_reload_conf()");
+print("cmd1 = $cmd1\n");
+my $stdout_buf= (run_command_and_exit_iferr ($cmd1))[3];
+print("stdout_buf = @$stdout_buf\n");
+sleep(0.5); #for the reload to be ready
+
+# Validate the two gucs are ON
+my $cmd2 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $host -p $port -d $database -c "show spock.enable_ddl_replication" -c "show spock.include_ddl_repset");
+print("cmd2 = $cmd2\n");
+my $stdout_buf1= (run_command_and_exit_iferr ($cmd2))[3];
+#combining a multi line output into a single line to ensure consistent comparisons to avoid random \n messing up comparisons
+@$stdout_buf1 = join(' ', map { sanitize_and_combine_multiline_stdout($_) } @$stdout_buf1);
+print("stdout_buf1 = @$stdout_buf1\n");
+
+if (contains($stdout_buf1->[0], "on on"))
+{
+    print("AutoDDL Gucs spock.enable_ddl_replication and spock.include_ddl_repset are now enabled");
+    exit(0);
+}
+else
+{
+    print("AutoDDL Gucs spock.enable_ddl_replication and spock.include_ddl_repset are NOT enabled. Exiting with failure");
+    exit(1);
+}

--- a/test/t/6910_teardown_autoddl_gucs_off_n1.pl
+++ b/test/t/6910_teardown_autoddl_gucs_off_n1.pl
@@ -1,0 +1,52 @@
+# This testcase turns off the the two primary auto ddl gucs 
+# spock.enable_ddl_replication AND spock.include_ddl_repset
+# on node 1 and performs a reload.
+#
+use strict;
+use warnings;
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+use edge;
+
+# Our parameters are:
+
+my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
+my $host = $ENV{EDGE_HOST};
+my $port = $ENV{EDGE_START_PORT};
+my $database = $ENV{EDGE_DB};
+print("The home directory of node 1 is $homedir1\n");
+
+# command to enable spock.enable_ddl_replication 
+my $enableDDLRep = qq(alter system set spock.enable_ddl_replication = off);
+# command to enable spock.include_ddl_repset
+my $includeDDLRep = qq(alter system set spock.include_ddl_repset = off);
+# execute the two alter syste commands followed by a server reload
+# all commands cannot be combined in a single -c switch
+my $cmd1 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $host -p $port -d $database -c "$enableDDLRep" -c "$includeDDLRep" -c "select pg_reload_conf()");
+print("cmd1 = $cmd1\n");
+my $stdout_buf= (run_command_and_exit_iferr ($cmd1))[3];
+print("stdout_buf = @$stdout_buf\n");
+sleep(0.5); #for the reload to be ready
+
+# Validate the two gucs are off
+my $cmd2 = qq($homedir1/$ENV{EDGE_COMPONENT}/bin/psql -t -h $host -p $port -d $database -c "show spock.enable_ddl_replication" -c "show spock.include_ddl_repset");
+print("cmd2 = $cmd2\n");
+my $stdout_buf1= (run_command_and_exit_iferr ($cmd2))[3];
+#combining a multi line output into a single line to ensure consistent comparisons to avoid random \n messing up comparisons
+@$stdout_buf1 = join(' ', map { sanitize_and_combine_multiline_stdout($_) } @$stdout_buf1);
+print("stdout_buf1 = @$stdout_buf1\n");
+
+if (contains($stdout_buf1->[0], "off off"))
+{
+    print("AutoDDL Gucs spock.enable_ddl_replication and spock.include_ddl_repset are now off");
+    exit(0);
+}
+else
+{
+    print("AutoDDL Gucs spock.enable_ddl_replication and spock.include_ddl_repset are NOT off. Exiting with failure");
+    exit(1);
+}

--- a/test/t/6911_teardown_autoddl_gucs_off_n2.pl
+++ b/test/t/6911_teardown_autoddl_gucs_off_n2.pl
@@ -1,0 +1,52 @@
+# This testcase enables the the two primary auto ddl gucs 
+# spock.enable_ddl_replication AND spock.include_ddl_repset
+# on node 2 and performs a reload.
+#
+use strict;
+use warnings;
+use File::Which;
+use IPC::Cmd qw(run);
+use Try::Tiny;
+use JSON;
+use lib './t/lib';
+use contains;
+use edge;
+
+# Our parameters are:
+
+my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
+my $host = $ENV{EDGE_HOST};
+my $port = $ENV{'EDGE_START_PORT'} + 1;
+my $database = $ENV{EDGE_DB};
+print("The home directory of node 2 is $homedir2\n");
+
+# command to enable spock.enable_ddl_replication 
+my $enableDDLRep = qq(alter system set spock.enable_ddl_replication = off);
+# command to enable spock.include_ddl_repset
+my $includeDDLRep = qq(alter system set spock.include_ddl_repset = off);
+# execute the two alter syste commands followed by a server reload
+# all commands cannot be combined in a single -c switch
+my $cmd1 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $host -p $port -d $database -c "$enableDDLRep" -c "$includeDDLRep" -c "select pg_reload_conf()");
+print("cmd1 = $cmd1\n");
+my $stdout_buf= (run_command_and_exit_iferr ($cmd1))[3];
+print("stdout_buf = @$stdout_buf\n");
+sleep(0.5); #for the reload to be ready
+
+# Validate the two gucs are OFF
+my $cmd2 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql -t -h $host -p $port -d $database -c "show spock.enable_ddl_replication" -c "show spock.include_ddl_repset");
+print("cmd2 = $cmd2\n");
+my $stdout_buf1= (run_command_and_exit_iferr ($cmd2))[3];
+#combining a multi line output into a single line to ensure consistent comparisons to avoid random \n messing up comparisons
+@$stdout_buf1 = join(' ', map { sanitize_and_combine_multiline_stdout($_) } @$stdout_buf1);
+print("stdout_buf1 = @$stdout_buf1\n");
+
+if (contains($stdout_buf1->[0], "off off"))
+{
+    print("AutoDDL Gucs spock.enable_ddl_replication and spock.include_ddl_repset are now off");
+    exit(0);
+}
+else
+{
+    print("AutoDDL Gucs spock.enable_ddl_replication and spock.include_ddl_repset are NOT off. Exiting with failure");
+    exit(1);
+}


### PR DESCRIPTION
Includes setup tasks for creating nodes / subscriptions, enabling autoddl GUCs.
Includes teardown tasks for dropping subscriptions and nodes, disabling GUCs.