### PR TITLE
Use the first entry in array of databases

### DIFF
--- a/cli/scripts/ace.py
+++ b/cli/scripts/ace.py
@@ -362,10 +362,11 @@ def init_db_connection(shared_objects, worker_state):
     db, pg, node_info = cluster.load_json(shared_objects["cluster_name"])
 
     cluster_nodes = []
+    database = db[0]
+    database["db_name"] = database.pop("name")
 
     # Combine db and cluster_nodes into a single json
-    for database, node in zip(db, node_info):
-        database["db_name"] = database.pop("name")
+    for node in node_info:
         combined_json = {**database, **node}
         cluster_nodes.append(combined_json)
 

--- a/cli/scripts/ace.py
+++ b/cli/scripts/ace.py
@@ -564,9 +564,15 @@ def table_diff(
 
     cluster_nodes = []
 
+    '''
+    Even though multiple databases are allowed, ACE will, for now,
+    only take the first entry in the db list
+    '''
+    database = db[0]
+    database["db_name"] = database.pop("name")
+
     # Combine db and cluster_nodes into a single json
-    for database, node in zip(db, node_info):
-        database["db_name"] = database.pop("name")
+    for node in node_info:
         combined_json = {**database, **node}
         cluster_nodes.append(combined_json)
 


### PR DESCRIPTION
This tweaks the ACE connection string cache to use only the first entry in the array of databases from the cluster.json file. We have yet to decide how to support multiple databases when they are present. This is not a limitation of any sort but simply a yet-to-be-made decision on how these databases are represented in the json file. Once it's done, ACE can use the respective database names and connection info for each node in the cluster.  