### PR TITLE
Updated syntax and path in util_test.py

### DIFF
--- a/test/t/util_test.py
+++ b/test/t/util_test.py
@@ -18,7 +18,7 @@ def get_settings():
     return port_n1, port_n2, host_n1, host_n2, db, usr, pw, repuser, pgv, repo
 
 def set_env():
-    load_dotenv(dotenv_path='lib/config.env')
+    load_dotenv('t/lib/config.env')
 
 
 ## abruptly terminate with a codified message


### PR DESCRIPTION
I've modified the syntax/path in the set_env() function to:

def set_env():
    load_dotenv('t/lib/config.env')
