### PR TITLE
Pause replication during table-repair

### DIFF
--- a/cli/scripts/ace.py
+++ b/cli/scripts/ace.py
@@ -740,6 +740,7 @@ def table_diff(
         offsets = [x for x in range(0, row_count + 1, block_rows)]
 
     cols_list = cols.split(",")
+    cols_list = [col for col in cols_list if not col.startswith("_Spock_")]
 
     # Shared variables needed by all workers
     shared_objects = {
@@ -1029,6 +1030,7 @@ def table_rerun(cluster_name, diff_file, table_name):
         diff_values[node_pair] = list(diff_values[node_pair])
 
     cols_list = cols.split(",")
+    cols_list = [col for col in cols_list if not col.startswith("_Spock_")]
 
     def run_query(cur, query):
         cur.execute(query)

--- a/cli/scripts/ace.py
+++ b/cli/scripts/ace.py
@@ -1063,8 +1063,12 @@ def table_rerun(cluster_name, diff_file, table_name):
                     ]
 
                     t1_result, t2_result = [f.result() for f in futures]
-                    node1_set.add(t1_result[0])
-                    node2_set.add(t2_result[0])
+
+                    t1_result = [tuple(str(x) if type(x) != list else str(sorted(x)) for x in row) for row in t1_result]
+                    t2_result = [tuple(str(x) if type(x) != list else str(sorted(x)) for x in row) for row in t2_result]
+
+                    node1_set = OrderedSet(t1_result)
+                    node2_set = OrderedSet(t2_result)
         else:
             for indices in values:
                 sql = f"""
@@ -1089,10 +1093,12 @@ def table_rerun(cluster_name, diff_file, table_name):
                     ]
 
                     t1_result, t2_result = [f.result() for f in futures]
-                    if t1_result:
-                        node1_set.add(t1_result[0])
-                    if t2_result:
-                        node2_set.add(t2_result[0])
+
+                    t1_result = [tuple(str(x) if type(x) != list else str(sorted(x)) for x in row) for row in t1_result]
+                    t2_result = [tuple(str(x) if type(x) != list else str(sorted(x)) for x in row) for row in t2_result]
+
+                    node1_set = OrderedSet(t1_result)
+                    node2_set = OrderedSet(t2_result)
 
         node1_diff = node1_set - node2_set
         node2_diff = node2_set - node1_set

--- a/cli/scripts/meta.py
+++ b/cli/scripts/meta.py
@@ -49,6 +49,27 @@ def get_installed_pg():
 
     return data
 
+'''
+Accepts a connection object and returns the version of spock installed
+
+@param: conn - connection object
+@return: float - version of spock installed
+
+'''
+def get_spock_version(conn):
+    data = []
+    sql = "SELECT spock.spock_version();"
+    try:
+        c = conn.cursor()
+        c.execute(sql)
+        data = c.fetchone()
+        if data:
+            return float(data[0])
+    except Exception as e:
+        fatal_error(e, sql, "get_spock_version()")
+
+    return 0.0
+
 
 def get_stage(p_comp):
     try:


### PR DESCRIPTION
* Ignore `_Spock_*` columns in ace operations
* Update table-rerun to account for list datatypes