### PR TITLE
Fixing typos in schedule_files/repset_tests

### DIFF
--- a/test/schedule_files/repset_tests
+++ b/test/schedule_files/repset_tests
@@ -124,12 +124,12 @@ t/spock_sub_remove_repset.py
 t/spock_sub_remove_repset_error.py
 
 ##
-# spock repset-create errors
-# #
+# spock repset-create errors 
+##
 
-spock_repset_create_error_1.py
-spock_repset_create_error_2.py
-spock_repset_create_error_3.py
+t/spock_repset_create_error_1.py
+t/spock_repset_create_error_2.py
+t/spock_repset_create_error_3.py
 
 ##
 # uninstall pgedge


### PR DESCRIPTION
I've corrected the path names (my typo) in the repset_tests schedule.