### PR TITLE
Correct typo in ace_1_setup.py

### DIFF
--- a/test/t/ace_1_setup.py
+++ b/test/t/ace_1_setup.py
@@ -45,7 +45,7 @@ for n in range(1,num_nodes+1):
     print(f"Created tables on n{n}")
 
 
-    cmd_node = f"spock repset-add-table default 'public.foo' {db}"
+    cmd_node = f"spock repset-add-table default 'public.foo' {dbname}"
     res=util_test.run_home_cmd("add tables to repset", cmd_node, f"{cluster_dir}/n{n}/pgedge")
     print(f"Added tables to repset on n{n}")
 

--- a/test/t/util_test.py
+++ b/test/t/util_test.py
@@ -109,8 +109,8 @@ def write_psql(cmd,host,dbname,port,pw,usr):
     con = get_pg_con(host,dbname,port,pw,usr)
     try:
         cur = con.cursor()
-        print(cur)
         cur.execute(cmd)
+        print(cur.statusmessage)
         ret = 0
         con.commit()
         cur.close()


### PR DESCRIPTION
I think the reference to {db} on line 48 should have been to {dbname}?