### PR TITLE
Initial check in of work on sub_tests schedule and supporting .py files

### DIFF
--- a/test/schedule_files/sub_tests
+++ b/test/schedule_files/sub_tests
@@ -1,0 +1,35 @@
+##
+# setup scripts
+##
+t/8000a_env_setup_pgedge_node1.pl
+t/8001a_env_setup_pgedge_node2.pl
+t/8000b_install_pgedge_node1.pl
+t/8001b_install_pgedge_node2.pl
+
+##
+# error tests
+##
+
+t/spock_node_create_no_node_name.py
+t/spock_node_create_no_repset_user.py
+t/spock_node_create_no_dbname.py
+t/spock_node_create_no_dns.py
+
+##
+# sub --synchronize struct tests
+
+t/spock_sub_create_synch_struct_n1.py
+t/spock_sub_create_synch_struct_n2.py
+
+# cleanup scripts
+##
+t/8082_env_sub_drop_n1.pl
+t/8083_env_sub_drop_n2.pl
+t/8086_env_node_drop_n1.pl
+t/8087_env_node_drop_n2.pl
+
+##
+# uninstall pgedge
+##
+t/8998_env_remove_pgedge_node1.pl
+t/8999_env_remove_pgedge_node2.pl

--- a/test/t/spock_node_create_no_dbname.py
+++ b/test/t/spock_node_create_no_dbname.py
@@ -1,0 +1,52 @@
+# This test case tests what happens if a node name is not provided when creating a node.
+
+import sys, os, util_test,subprocess
+
+# Print Script
+print(f"Starting - {os.path.basename(__file__)}")
+
+# Get Test Settings
+util_test.set_env()
+repo=os.getenv("EDGE_REPO")
+num_nodes=int(os.getenv("EDGE_NODES",2))
+cluster_dir=os.getenv("EDGE_CLUSTER_DIR")
+port=int(os.getenv("EDGE_START_PORT",6432))
+usr=os.getenv("EDGE_USERNAME","lcusr")
+pw=os.getenv("EDGE_PASSWORD","password")
+db=os.getenv("EDGE_DB","demo")
+host=os.getenv("EDGE_HOST","localhost")
+repuser=os.getenv("EDGE_REPUSER","repuser")
+repset=os.getenv("EDGE_REPSET","demo-repset")
+spockpath=os.getenv("EDGE_SPOCK_PATH")
+dbname=os.getenv("EDGE_DB","lcdb")
+#
+# Check for "n1", and drop it if it exists; then we'll use spock node-create to create errors. This way we can play the tests out of order.
+# 
+check_value = util_test.read_psql("select * from spock.node;",host,dbname,port,pw,usr).strip("[]")
+print(f"Check value is: {check_value}")
+
+if "n1" in str(check_value):
+    drop_node = f"spock node-drop n1 {dbname}"
+    drop=util_test.run_cmd("Run spock node-drop.", drop_node, f"{cluster_dir}/n1")
+    print(f"Print drop.stdout here: - {drop.stdout}")
+print("*"*100)
+
+# Invoke spock node-create, but don't specify a database name:
+
+command = f"spock node-create n1 'host={host} user={repuser} dbname={dbname}'"
+res=util_test.run_cmd("Run spock node-create.", command, f"{cluster_dir}/n1")
+print(f"Print res.stderr here: - {res.stderr}")
+
+print("*"*100)
+
+# Needle and Haystack
+# Confirm the test works by looking for 'ERROR' in res.stderr:
+if "ERROR" in str(res.stderr):
+    util_test.EXIT_FAIL
+else:
+    util_test.EXIT_PASS
+
+print("*"*100)
+
+
+

--- a/test/t/spock_node_create_no_dns.py
+++ b/test/t/spock_node_create_no_dns.py
@@ -1,0 +1,52 @@
+# This test case tests what happens if a node name is not provided when creating a node.
+
+import sys, os, util_test,subprocess
+
+# Print Script
+print(f"Starting - {os.path.basename(__file__)}")
+
+# Get Test Settings
+util_test.set_env()
+repo=os.getenv("EDGE_REPO")
+num_nodes=int(os.getenv("EDGE_NODES",2))
+cluster_dir=os.getenv("EDGE_CLUSTER_DIR")
+port=int(os.getenv("EDGE_START_PORT",6432))
+usr=os.getenv("EDGE_USERNAME","lcusr")
+pw=os.getenv("EDGE_PASSWORD","password")
+db=os.getenv("EDGE_DB","demo")
+host=os.getenv("EDGE_HOST","localhost")
+repuser=os.getenv("EDGE_REPUSER","repuser")
+repset=os.getenv("EDGE_REPSET","demo-repset")
+spockpath=os.getenv("EDGE_SPOCK_PATH")
+dbname=os.getenv("EDGE_DB","lcdb")
+#
+# Check for "n1", and drop it if it exists; then we'll use spock node-create to create errors. This way we can play the tests out of order.
+# 
+check_value = util_test.read_psql("select * from spock.node;",host,dbname,port,pw,usr).strip("[]")
+print(f"Check value is: {check_value}")
+
+if "n1" in str(check_value):
+    drop_node = f"spock node-drop n1 {dbname}"
+    drop=util_test.run_cmd("Run spock node-drop.", drop_node, f"{cluster_dir}/n1")
+    print(f"Print drop.stdout here: - {drop.stdout}")
+print("*"*100)
+
+# Invoke spock node-create, but don't specify a node name:
+
+command = f"spock node-create n1 {dbname}"
+res=util_test.run_cmd("Run spock node-create.", command, f"{cluster_dir}/n1")
+print(f"Print res.stderr here: - {res.stderr}")
+
+print("*"*100)
+
+# Needle and Haystack
+# Confirm the test works by looking for 'ERROR' in res:
+if "ERROR" in str(res):
+    util_test.EXIT_FAIL
+else:
+    util_test.EXIT_PASS
+
+print("*"*100)
+
+
+

--- a/test/t/spock_node_create_no_node_name.py
+++ b/test/t/spock_node_create_no_node_name.py
@@ -1,0 +1,52 @@
+# This test case tests what happens if a node name is not provided when creating a node.
+
+import sys, os, util_test,subprocess
+
+# Print Script
+print(f"Starting - {os.path.basename(__file__)}")
+
+# Get Test Settings
+util_test.set_env()
+repo=os.getenv("EDGE_REPO")
+num_nodes=int(os.getenv("EDGE_NODES",2))
+cluster_dir=os.getenv("EDGE_CLUSTER_DIR")
+port=int(os.getenv("EDGE_START_PORT",6432))
+usr=os.getenv("EDGE_USERNAME","lcusr")
+pw=os.getenv("EDGE_PASSWORD","password")
+db=os.getenv("EDGE_DB","demo")
+host=os.getenv("EDGE_HOST","localhost")
+repuser=os.getenv("EDGE_REPUSER","repuser")
+repset=os.getenv("EDGE_REPSET","demo-repset")
+spockpath=os.getenv("EDGE_SPOCK_PATH")
+dbname=os.getenv("EDGE_DB","lcdb")
+#
+# Check for "n1", and drop it if it exists; then we'll use spock node-create to create errors. This way we can play the tests out of order.
+# 
+check_value = util_test.read_psql("select * from spock.node;",host,dbname,port,pw,usr).strip("[]")
+print(f"Check value is: {check_value}")
+
+if "n1" in str(check_value):
+    drop_node = f"spock node-drop n1 {dbname}"
+    drop=util_test.run_cmd("Run spock node-drop.", drop_node, f"{cluster_dir}/n1")
+    print(f"Print drop.stdout here: - {drop.stdout}")
+print("*"*100)
+
+# Invoke spock node-create, but don't specify a node name:
+
+command = f"spock node-create 'host={host} user={repuser} dbname={dbname}' {dbname}"
+res=util_test.run_cmd("Run spock node-create.", command, f"{cluster_dir}/n1")
+print(f"Print res.stderr here: - {res.stderr}")
+
+print("*"*100)
+
+# Needle and Haystack
+# Confirm the test works by looking for 'ERROR' in res:
+if "ERROR" in str(res):
+    util_test.EXIT_FAIL
+else:
+    util_test.EXIT_PASS
+
+print("*"*100)
+
+
+

--- a/test/t/spock_node_create_no_repset_user.py
+++ b/test/t/spock_node_create_no_repset_user.py
@@ -1,0 +1,52 @@
+# This test case tests what happens if a node name is not provided when creating a node.
+
+import sys, os, util_test,subprocess
+
+# Print Script
+print(f"Starting - {os.path.basename(__file__)}")
+
+# Get Test Settings
+util_test.set_env()
+repo=os.getenv("EDGE_REPO")
+num_nodes=int(os.getenv("EDGE_NODES",2))
+cluster_dir=os.getenv("EDGE_CLUSTER_DIR")
+port=int(os.getenv("EDGE_START_PORT",6432))
+usr=os.getenv("EDGE_USERNAME","lcusr")
+pw=os.getenv("EDGE_PASSWORD","password")
+db=os.getenv("EDGE_DB","demo")
+host=os.getenv("EDGE_HOST","localhost")
+repuser=os.getenv("EDGE_REPUSER","repuser")
+repset=os.getenv("EDGE_REPSET","demo-repset")
+spockpath=os.getenv("EDGE_SPOCK_PATH")
+dbname=os.getenv("EDGE_DB","lcdb")
+#
+# Check for "n1", and drop it if it exists; then we'll use spock node-create to create errors. This way we can play the tests out of order.
+# 
+check_value = util_test.read_psql("select * from spock.node;",host,dbname,port,pw,usr).strip("[]")
+print(f"Check value is: {check_value}")
+
+if "n1" in str(check_value):
+    drop_node = f"spock node-drop n1 {dbname}"
+    drop=util_test.run_cmd("Run spock node-drop.", drop_node, f"{cluster_dir}/n1")
+    print(f"Print drop.stdout here: - {drop.stdout}")
+print("*"*100)
+
+# Invoke spock node-create, but don't specify a node name:
+
+command = f"spock node-create n1 'host={host} user={usr} dbname={dbname}' {dbname}"
+res=util_test.run_cmd("Run spock node-create.", command, f"{cluster_dir}/n1")
+print(f"Print res here: - {res}")
+
+print("*"*100)
+
+# Needle and Haystack
+# Confirm the test works by looking for 'replication user' in res:
+if "replication user" in str(res):
+    util_test.EXIT_FAIL
+else:
+    util_test.EXIT_PASS
+
+print("*"*100)
+
+
+

--- a/test/t/spock_sub_create_synch_struct_n1.py
+++ b/test/t/spock_sub_create_synch_struct_n1.py
@@ -1,0 +1,55 @@
+import sys, os, util_test,subprocess
+
+# Print Script
+print(f"Starting - {os.path.basename(__file__)}")
+
+# Get Test Settings
+util_test.set_env()
+
+cluster_dir=os.getenv("EDGE_CLUSTER_DIR")
+port=int(os.getenv("EDGE_START_PORT",6432))
+usr=os.getenv("EDGE_USERNAME","lcusr")
+pw=os.getenv("EDGE_PASSWORD","password")
+host=os.getenv("EDGE_HOST","localhost")
+repuser=os.getenv("EDGE_REPUSER","repuser")
+dbname=os.getenv("EDGE_DB","lcdb")
+
+## Check for n1, and drop it if it exists.
+#
+check_node = util_test.read_psql("select * from spock.node;",host,dbname,port,pw,usr).strip("[]")
+print(f"Check for existence of n1: {check_node}")
+
+if "n1" in str(check_node):
+    drop_node = f"spock node-drop n1 {dbname}"
+    drop=util_test.run_cmd("Run spock node-drop.", drop_node, f"{cluster_dir}/n1")
+    print(f"Print drop.stdout here: - {drop.stdout}")
+print("*"*100)
+
+# Create a new n1:
+command = f"spock node-create n1 'host={host} user={repuser} dbname={dbname}' {dbname}"
+res=util_test.run_cmd("Run spock node-create.", command, f"{cluster_dir}/n1")
+print(f"Print res here: - {res}")
+print("*"*100)
+
+# Define a table named foo on n1 - this should echo back 'CREATE TABLE'
+create_table = util_test.write_psql("CREATE TABLE IF NOT EXISTS foo (empid INT PRIMARY KEY, empname varchar(40))",host,dbname,port,pw,usr)
+print("*"*100)
+
+# Add the table to the 'default' repset.
+command = (f"spock repset-add-table default 'public.foo' {dbname}")
+repset_add=util_test.run_cmd("Run spock repset-add-table.", command, f"{cluster_dir}/n1")
+print(f"Print repset_add here: - {repset_add}")
+print("*"*100)
+
+# Needle and Haystack
+# Confirm the test works by looking for 'Adding' in res.stdout:
+if "Adding" in str(repset_add.stdout):
+    util_test.EXIT_PASS
+else:
+    util_test.EXIT_FAIL
+
+
+
+
+
+

--- a/test/t/spock_sub_create_synch_struct_n2.py
+++ b/test/t/spock_sub_create_synch_struct_n2.py
@@ -1,0 +1,58 @@
+import sys, os, util_test,subprocess
+
+# Print Script
+print(f"Starting - {os.path.basename(__file__)}")
+
+# Get Test Settings
+util_test.set_env()
+
+
+cluster_dir=os.getenv("EDGE_CLUSTER_DIR")
+port=int(os.getenv("EDGE_START_PORT",6432))
+usr=os.getenv("EDGE_USERNAME","lcusr")
+pw=os.getenv("EDGE_PASSWORD","password")
+host=os.getenv("EDGE_HOST","localhost")
+repuser=os.getenv("EDGE_REPUSER","repuser")
+dbname=os.getenv("EDGE_DB","lcdb")
+
+n2_port = port + 1
+
+print(f"port (n1) is set to {port}")
+print(f"n2_port is set to {n2_port}")
+
+# Check for n2, and drop it if it exists.
+check_node = util_test.read_psql("select * from spock.node;",host,dbname,n2_port,pw,usr).strip("[]")
+
+if "n2" in str(check_node):
+    drop_node = f"spock node-drop n2 {dbname}"
+    drop=util_test.run_cmd("Run spock node-drop.", drop_node, f"{cluster_dir}/n2")
+    print(f"Print drop.stdout here: - {drop.stdout}")
+print("*"*100)
+
+# Create a new n2:
+command = (f"spock node-create n2 'host={host} user={repuser} dbname={dbname} port={n2_port}' {dbname}")
+res=util_test.run_cmd("Run spock node-create.", command, f"{cluster_dir}/n2")
+print(f"spock node-create n2 returned: {res.stdout}")
+print("*"*100)
+
+# We're not going to create the table on n2; instead, we'll create the subscription with --synchronize-struct=True to pull the structure over.
+command = (f"spock sub-create sub_n2n1 'host={host} port={port} user={repuser} dbname={dbname}' {dbname} --synchronize_structure=True")
+sub_create=util_test.run_cmd("Run spock sub-create sub_n2n1.", command, f"{cluster_dir}/n2")
+print(f"The spock sub-create command for sub_n2n1 returned: {sub_create.stdout}")
+print("*"*100)
+
+# Check for public.foo in pg_tables:
+rep_check = util_test.read_psql("SELECT * FROM pg_tables WHERE schemaname = 'public';",host,dbname,n2_port,pw,usr)
+
+# Needle and Haystack
+# Confirm the test works by looking for 'foo' in rep_check:
+if "foo" in str(rep_check):
+    util_test.EXIT_PASS
+else:
+    util_test.EXIT_FAIL
+
+
+
+
+
+

--- a/test/t/util_test.py
+++ b/test/t/util_test.py
@@ -109,8 +109,8 @@ def write_psql(cmd,host,dbname,port,pw,usr):
     con = get_pg_con(host,dbname,port,pw,usr)
     try:
         cur = con.cursor()
-        print(cur)
         cur.execute(cmd)
+        print(cur.statusmessage)
         ret = 0
         con.commit()
         cur.close()
@@ -130,6 +130,7 @@ def read_psql(cmd,host,dbname,port,pw,usr):
     try:
         cur = con.cursor()
         cur.execute(cmd)
+        print(cmd)
         ret = json.dumps(cur.fetchall())
         cur.close()
     except Exception as e:


### PR DESCRIPTION
This schedule contains spock_node_create and spock_sub_create test cases - we may want to move the node test to their own schedule at some point, but for now, they work with the 8000 build/teardown scripts so I've added them here.