### PR TITLE
Add support for adding new nodes to cluster.

### DIFF
--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -2,7 +2,7 @@
 #  Copyright 2022-2024 PGEDGE  All rights reserved. #
 
 import os, json, datetime
-import util, fire, meta, time
+import util, utilx, fire, meta, time, sys
 
 BASE_DIR = "cluster"
 
@@ -13,7 +13,7 @@ def ssh(cluster_name, node_name):
    
     for nd in nodes:
        if node_name == nd["name"]:
-          util.echo_cmd(f'ssh -i ~/keys/eqn-test-key {nd["os_user"]}@{nd["ip_address"]}')
+          utilx.echo_cmd(f'ssh -i ~/keys/eqn-test-key {nd["os_user"]}@{nd["ip_address"]}')
           util.exit_cleanly(0)
 
     util.exit_message(f"Could not locate node '{node_name}'")
@@ -23,10 +23,10 @@ def set_firewalld(cluster_name):
     """ Open up nodes only to each other on pg port (WIP)"""
     
     ## install & start firewalld if not present
-    rc = util.echo_cmd("sudo firewall-cmd --version")
+    rc = utilx.echo_cmd("sudo firewall-cmd --version")
     if rc != 0:
-       rc = util.echo_cmd("sudo dnf install -y firewalld")
-       rc = util.echo_cmd("sudo systemctl start firewalld")
+       rc = utilx.echo_cmd("sudo dnf install -y firewalld")
+       rc = utilx.echo_cmd("sudo systemctl start firewalld")
 
     db, db_settings, nodes = load_json(cluster_name)
 
@@ -108,7 +108,6 @@ def json_create(cluster_name, style, db="demo", user="user1", passwd="passwd1", 
 
 def json_add_node(cluster_name, node_group, node_name, is_active, ip_address, port, path, os_user=None, ssh_key=None, provider=None, airport=None):
     cj = get_cluster_json (cluster_name)
-
     util.message(f"json_add_node()\n{json.dumps(cj, indent=2)}", "debug")
 
     node_json = {}
@@ -143,7 +142,7 @@ def create_remote_json(
     """Create a template for a Cluster Configuration JSON file.
     
        Create a JSON configuration file template that can be modified to fully define a remote cluster. \n
-       Example: cluster define-remote demo lcdb 3 lcusr lcpasswd 16 5432
+       Example: cluster define-remote demo db[0]["name"] 3 lcusr lcpasswd 16 5432
        :param cluster_name: The name of the cluster. A directory with this same name will be created in the cluster directory, and the JSON file will have the same name.
        :param db: The database name.
        :param num_nodes: The number of nodes in the cluster.
@@ -271,7 +270,6 @@ def load_json(cluster_name):
                     node.append(n)  
             else:
                 util.exit_message("localhost info missing from JSON", 1)
-       
     return (
         db,
         db_settings,
@@ -330,13 +328,13 @@ def remove(cluster_name, force=False):
     util.message("\n## Ensure that PG is stopped.")
     for nd in nodes:
         cmd = nd["path"] + os.sep + "pgedge stop 2> " + os.sep + "dev" + os.sep + "null"
-        util.echo_cmd(cmd, host=nd["ip_address"], usr=nd["os_user"], key=nd["ssh_key"])
+        utilx.echo_cmd(cmd, host=nd["ip_address"], usr=nd["os_user"], key=nd["ssh_key"])
 
     if force == True:
         util.message("\n## Ensure that pgEdge root directory is gone")
         for nd in nodes:
             cmd = f"rm -rf " + nd["path"] + os.sep + "pgedge"
-            util.echo_cmd(cmd, host=nd["ip_address"], usr=nd["os_user"], key=nd["ssh_key"])
+            utilx.echo_cmd(cmd, host=nd["ip_address"], usr=nd["os_user"], key=nd["ssh_key"])
 
 
 def init(cluster_name):
@@ -354,7 +352,7 @@ def init(cluster_name):
 
     util.message("\n## Checking ssh'ing to each node")
     for nd in nodes:
-        rc = util.echo_cmd(
+        rc = utilx.echo_cmd(
             usr=nd["os_user"], host=nd["ip_address"], key=nd["ssh_key"], cmd="hostname"
         )
         if rc == 0:
@@ -362,7 +360,7 @@ def init(cluster_name):
         else:
             util.exit_message("cannot ssh to node")
 
-    ssh_install_pgedge(cluster_name, db[0]["name"], db_settings, db[0]["username"], db[0]["password"], nodes)
+    ssh_install_pgedge_all(cluster_name, db[0]["name"], db_settings, db[0]["username"], db[0]["password"], nodes)
     ssh_cross_wire_pgedge(cluster_name, db[0]["name"], db_settings, db[0]["username"], db[0]["password"], nodes)
     if len(db) > 1:
         for database in db[1:]:
@@ -415,68 +413,85 @@ def add_db(cluster_name, database_name, username, password):
 
 
 def print_install_hdr(cluster_name, db, db_user, count):
-    util.message("#")
-    util.message(
-        f"######## ssh_install_pgedge: cluster={cluster_name}, db={db}, db_user={db_user}, count={count}"
-    )
+    n = {
+    "nodes": [
+        {
+            "cluster": cluster_name,
+            "db": True,
+            "db_user": db,
+            "count": count
+        }
+    ]
+    }
+    utilx.echo_node(n)
 
-
-def ssh_install_pgedge(cluster_name, db, db_settings, db_user, db_passwd, nodes):
-    """Install pgEdge on every node in a cluster."""
-
+def ssh_install_pgedge_all(cluster_name, db, db_settings, db_user, db_passwd, nodes):
+    print_install_hdr(cluster_name, db, db_user, len(nodes))
     for n in nodes:
-        print_install_hdr(cluster_name, db, db_user, len(nodes))
-        ndnm = n["name"]
-        ndpath = n["path"]
-        ndip = n["ip_address"]
-        try:
-            ndport = str(n["port"])
-        except Exception:
-            ndport = "5432"
+        ssh_install_pgedge(cluster_name, db, db_settings, db_user, db_passwd, n)
+        ssh_setup_pgedge(cluster_name, db, db_settings, db_user, db_passwd, n)
 
-        REPO = os.getenv("REPO", "")
-        if REPO == "":
-            REPO = "https://pgedge-upstream.s3.amazonaws.com/REPO"
-            os.environ["REPO"] = REPO
+def ssh_install_pgedge(cluster_name, db, db_settings, db_user, db_passwd, n):
+    ndnm = n["name"]
+    ndpath = n["path"]
+    ndip = n["ip_address"]
+    utilx.echo_node(n)
+    try:
+        ndport = str(n["port"])
+    except Exception:
+        ndport = "5432"
 
-        install_py = "install.py"
+    REPO = os.getenv("REPO", "")
+    if REPO == "":
+        REPO = "https://pgedge-upstream.s3.amazonaws.com/REPO"
+        os.environ["REPO"] = REPO
 
-        util.message(
-            f"########                node={ndnm}, host={ndip}, path={ndpath} REPO={REPO}\n"
-        )
-        pg = db_settings["pg_version"]
-        spock = db_settings["spock_version"]        
+    install_py = "install.py"
 
-        cmd0 = f"export REPO={REPO}; "
-        cmd1 = f"mkdir -p {ndpath}; cd {ndpath}; "
-        cmd2 = f'python3 -c "\\$(curl -fsSL {REPO}/{install_py})"'
-        util.echo_cmd(cmd0 + cmd1 + cmd2, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    cmd0 = f"export REPO={REPO}; "
+    cmd1 = f"mkdir -p {ndpath}; cd {ndpath}; "
+    cmd2 = f'python3 -c "\\$(curl -fsSL {REPO}/{install_py})"'
+    rc = utilx.echo_cmd(cmd0 + cmd1 + cmd2, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    return rc
 
-        nc = os.path.join(ndpath, "pgedge", "pgedge ")
-        parms = f" -U {db_user} -P {db_passwd} -d {db} --port {ndport}"
-        if pg is not None and pg != '':
-            parms = parms + f" --pg {pg}"
-        if spock is not None and spock != '':
-            parms = parms + f" --spock_ver {spock}"
-        util.echo_cmd(f"{nc} setup {parms}", host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
-        if db_settings["auto_ddl"] == "on":
-            cmd = nc + " db guc-set spock.enable_ddl_replication on;"
-            cmd = cmd + " " + nc + " db guc-set spock.include_ddl_repset on;"
-            cmd = cmd + " " + nc + " db guc-set spock.allow_ddl_from_functions on;"
-            util.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
-        util.message("#")
-
+def ssh_setup_pgedge(cluster_name, db, db_settings, db_user, db_passwd, n):
+    rc = 0
+    ndnm = n["name"]
+    ndpath = n["path"]
+    ndip = n["ip_address"]
+    try:
+        ndport = str(n["port"])
+    except Exception:
+        ndport = "5432"
+    
+    pg = db_settings["pg_version"]
+    spock = db_settings["spock_version"]        
+    
+    nc = os.path.join(ndpath, "pgedge", "pgedge ")
+    parms = f" -U {db_user} -P {db_passwd} -d {db} --port {ndport}"
+    if pg is not None and pg != '':
+        parms = parms + f" --pg {pg}"
+    if spock is not None and spock != '':
+        parms = parms + f" --spock_ver {spock}"
+    utilx.echo_cmd(f"{nc} setup {parms}", host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    if db_settings["auto_ddl"] == "on":
+        cmd = nc + " db guc-set spock.enable_ddl_replication on;"
+        cmd = cmd + " " + nc + " db guc-set spock.include_ddl_repset on;"
+        cmd = cmd + " " + nc + " db guc-set spock.allow_ddl_from_functions on;"
+        rc = utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    util.message("#")
+    return rc
 
 def create_spock_db(nodes,db,db_settings):
     for n in nodes:
         nc = n["path"] + os.sep + "pgedge" + os.sep + "pgedge "
         cmd = nc + " db create -U " + db["username"] + " -d " + db["name"] + " -p " + db["password"]
-        util.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+        utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
         if db_settings["auto_ddl"] == "on":
             cmd = nc + " db guc-set spock.enable_ddl_replication on;"
             cmd = cmd + " " + nc + " db guc-set spock.include_ddl_repset on;"
             cmd = cmd + " " + nc + " db guc-set spock.allow_ddl_from_functions on;"
-            util.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+            utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
 
 def ssh_cross_wire_pgedge(cluster_name, db, db_settings, db_user, db_passwd, nodes):
     """Create nodes and subs on every node in a cluster."""
@@ -498,7 +513,7 @@ def ssh_cross_wire_pgedge(cluster_name, db, db_settings, db_user, db_passwd, nod
         except Exception:
             ndport = "5432"
         cmd1 = f"{nc} spock node-create {ndnm} 'host={ndip_private} user={os_user} dbname={db} port={ndport}' {db}"
-        util.echo_cmd(cmd1, host=ndip, usr=os_user, key=ssh_key)
+        utilx.echo_cmd(cmd1, host=ndip, usr=os_user, key=ssh_key)
         for sub_n in nodes:
             sub_ndnm = sub_n["name"]
             if sub_ndnm != ndnm:
@@ -521,7 +536,7 @@ def ssh_cross_wire_pgedge(cluster_name, db, db_settings, db_user, db_passwd, nod
         nip = n[1]
         os_user = n[2]
         ssh_key = n[3]
-        util.echo_cmd(cmd, host=nip, usr=os_user, key=ssh_key)
+        utilx.echo_cmd(cmd, host=nip, usr=os_user, key=ssh_key)
 
 
 def ssh_un_cross_wire(cluster_name, db, db_settings, db_user, db_passwd, nodes):
@@ -538,7 +553,7 @@ def ssh_un_cross_wire(cluster_name, db, db_settings, db_user, db_passwd, nodes):
             sub_ndnm = sub_n["name"]
             if sub_ndnm != ndnm:
                 cmd = f"{nc} spock sub-drop sub_{ndnm}{sub_ndnm} {db}"
-                util.echo_cmd(cmd, host=ndip, usr=os_user, key=ssh_key)
+                utilx.echo_cmd(cmd, host=ndip, usr=os_user, key=ssh_key)
 
     for prov_n in nodes:
         ndnm = prov_n["name"]
@@ -548,7 +563,7 @@ def ssh_un_cross_wire(cluster_name, db, db_settings, db_user, db_passwd, nodes):
         os_user = prov_n["os_user"]
         ssh_key = prov_n["ssh_key"]
         cmd1 = f"{nc} spock node-drop {ndnm} {db}"
-        util.echo_cmd(cmd1, host=ndip, usr=os_user, key=ssh_key)
+        utilx.echo_cmd(cmd1, host=ndip, usr=os_user, key=ssh_key)
     ## To Do: Check Nodes have been dropped
 
 
@@ -576,7 +591,7 @@ def replication_all_tables(cluster_name, database_name=None):
         os_user = n["os_user"]
         ssh_key = n["ssh_key"]
         cmd = f"{nc} spock repset-add-table default '*' {db_name}"
-        util.echo_cmd(cmd, host=ndip, usr=os_user, key=ssh_key)
+        utilx.echo_cmd(cmd, host=ndip, usr=os_user, key=ssh_key)
 
 
 def replication_check(cluster_name, show_spock_tables=False, database_name=None):
@@ -599,9 +614,9 @@ def replication_check(cluster_name, show_spock_tables=False, database_name=None)
         ssh_key = n["ssh_key"]
         if show_spock_tables == True:
             cmd = f"{nc} spock repset-list-tables '*' {db_name}"
-            util.echo_cmd(cmd, host=ndip, usr=os_user, key=ssh_key)
+            utilx.echo_cmd(cmd, host=ndip, usr=os_user, key=ssh_key)
         cmd = f"{nc} spock sub-show-status '*' {db_name}"
-        util.echo_cmd(cmd, host=ndip, usr=os_user, key=ssh_key)
+        utilx.echo_cmd(cmd, host=ndip, usr=os_user, key=ssh_key)
 
 
 def command(cluster_name, node, cmd, args=None):
@@ -610,7 +625,7 @@ def command(cluster_name, node, cmd, args=None):
        Run './pgedge' commands on one or all of the nodes in a cluster. 
        This command requires a JSON file with the same name as the cluster to be in the cluster/<cluster_name>. \n 
        Example: cluster command demo n1 "status"
-       Example: cluster command demo all "spock repset-add-table default '*' lcdb"
+       Example: cluster command demo all "spock repset-add-table default '*' db[0]["name"]"
        :param cluster_name: The name of the cluster.
        :param node: The node to run the command on. Can be the node name or all.
        :param cmd: The command to run on every node, excluding the beginning './pgedge' 
@@ -624,7 +639,7 @@ def command(cluster_name, node, cmd, args=None):
     for nd in nodes:
         if node == "all" or node == nd["name"]:
             knt = knt + 1
-            rc = util.echo_cmd(
+            rc = utilx.echo_cmd(
                 nd["path"] + os.sep + "pgedge" + os.sep + "pgedge " + cmd,
                 host=nd["ip_address"],
                 usr=nd["os_user"],
@@ -664,15 +679,14 @@ def app_install(cluster_name, app_name, database_name=None, factor=1):
         for n in nodes:
             ndpath = n["path"]
             ndip = n["ip_address"]
-            util.echo_cmd(f"{ndpath}{ctl} app pgbench-install {db_name} {factor} default", host=ndip, usr=n["os_user"], key=n["ssh_key"])
+            utilx.echo_cmd(f"{ndpath}{ctl} app pgbench-install {db_name} {factor} default", host=ndip, usr=n["os_user"], key=n["ssh_key"])
     elif app_name == "northwind":
         for n in nodes:
             ndpath = n["path"]
             ndip = n["ip_address"]
-            util.echo_cmd(f"{ndpath}{ctl} app northwind-install {db_name} default", host=ndip, usr=n["os_user"], key=n["ssh_key"])
+            utilx.echo_cmd(f"{ndpath}{ctl} app northwind-install {db_name} default", host=ndip, usr=n["os_user"], key=n["ssh_key"])
     else:
         util.exit_message(f"Invalid app_name '{app_name}'.")
-
 
 def app_remove(cluster_name, app_name, database_name=None):
     """Remove test application from cluster.
@@ -700,15 +714,324 @@ def app_remove(cluster_name, app_name, database_name=None):
          for n in nodes:
             ndpath = n["path"]
             ndip = n["ip_address"]
-            util.echo_cmd(f"{ndpath}{ctl} app pgbench-remove {db_name}", host=ndip, usr=n["os_user"], key=n["ssh_key"])
+            utilx.echo_cmd(f"{ndpath}{ctl} app pgbench-remove {db_name}", host=ndip, usr=n["os_user"], key=n["ssh_key"])
     elif app_name == "northwind":
          for n in nodes:
             ndpath = n["path"]
             ndip = n["ip_address"]
-            util.echo_cmd(f"{ndpath}{ctl} app northwind-remove {db}", host=ndip, usr=n["os_user"], key=n["ssh_key"])
+            utilx.echo_cmd(f"{ndpath}{ctl} app northwind-remove {db}", host=ndip, usr=n["os_user"], key=n["ssh_key"])
     else:
         util.exit_message("Invalid application name.")
 
+def list_nodes(cluster_name):
+    """List all nodes in the cluster."""
+    
+    cluster_data = get_cluster_json(cluster_name)
+
+    nodes_list = []
+    for group in cluster_data['node_groups']['localhost']:
+        for node in group['nodes']:
+            node_info = (
+                f"Node: {node['name']}, IP: {node['ip_address']}, "
+                f"Port: {node['port']}, Active: {'Yes' if node['is_active'] else 'No'}"
+            )
+            nodes_list.append(node_info)
+
+    return nodes_list
+
+def apply_s3_settings(config_file, path, host, usr, key):
+    try:
+        with open(config_file, 'r') as file:
+            for line in file:
+                if line.strip() and not line.startswith('#'):  # skip empty lines and comments
+                    key, value = line.strip().split('=')
+                    cmd = f"cd {path};./pgedge set BACKUP {key} {value}"
+                    utilx.echo_cmd(cmd, host, usr, key)
+    except FileNotFoundError:
+        util.exit_message("Error: S3 configuration file not found.")
+
+def add_node(cluster_name, source_node, target_node, stanza=" ", backup_id=" ", install_pgedge=True, setup_pgedge=True, verbose=False):
+    """
+    Adds a new node to a cluster, copying configurations from a specified source node.
+
+    Args:
+        cluster_name (str): The name of the cluster to which the node is being added.
+        source_node (str): The node from which configurations are copied.
+        target_node (str): The new node being added.
+        stanza(str): stanza name.
+        backup_id(str): backup id.
+        install_pgedge (bool): If True, installs pgEdge on the new node.
+        setup_pgedge (bool): If True, sets up pgEdge on the new node.
+    """
+    cluster_data = get_cluster_json(cluster_name)
+    stanza_create = False
+    if stanza == " ":
+        stanza = "pg16"
+        stanza_create = True
+    
+    node_file = f"{target_node}.json"
+    if not os.path.exists(node_file):
+        util.exit_message(f"Error: Missing node configuration file '{node_file}'.")
+        return
+
+    with open(node_file, 'r') as file:
+        node_data = json.load(file)
+    n = node_data["nodes"][0]
+    
+    node_groups = cluster_data.get('node_groups', {})
+    nodes = node_groups.get('aws', [])
+
+    for node_group in nodes:
+        nodes = node_group.get('nodes', [])
+        for node in nodes:
+            if node.get('name') == n['name']:
+                util.exit_message(f"Error: node {n['name']} already exists.")
+                break
+
+    db, db_settings, nodes = load_json(cluster_name)
+    s = next((node for node in nodes if node['name'] == source_node), None)
+    if s is None:
+        util.exit_message(f"Error: Source node '{source_node}' not found in cluster data.")
+        return
+
+    dbname = db[0]["name"]
+    # Copy necessary details from source node
+    n.update({
+        'os_user': s['os_user'],
+        'ssh_key': s['ssh_key'],
+    })
+
+    utilx.echo_message(f"Installing and Configuring new node", bold=True)
+    
+    if install_pgedge == True:
+        utilx.echo_action(f"Installing postgresql ")
+        rc = ssh_install_pgedge(cluster_name, db[0]["name"], db_settings, db[0]["username"], db[0]["password"], n)
+        if (rc == 0):    
+            utilx.echo_action(f"Installing postgresql ", "ok")
+        else:
+            utilx.echo_action(f"Installing postgresql ", "failed", True)
+
+    if setup_pgedge == True:
+        utilx.echo_action(f"Installing pgedge ")
+        rc = ssh_setup_pgedge(cluster_name, db[0]["name"], db_settings, db[0]["username"], db[0]["password"], n)
+        if (rc == 1):    
+            utilx.echo_action(f"Installing pgedge ", "failed", True)
+   
+    apply_s3_settings("pgedge-s3.conf", path = f"{s['path']}/pgedge/", host=s["ip_address"], usr=s["os_user"], key=["ssh_key"])
+
+    cmd = f'''
+    cd {s['path']}/pgedge/;
+    ./pgedge install backrest;
+    ./pgedge set BACKUP stanza_count 1;
+    ./pgedge set BACKUP repo1-path /var/lib/pgbackrest/{s["name"]};
+    ./pgedge set BACKUP repo1-host " ";
+    ./pgedge set BACKUP repo1-cipher-pass pgedge;
+    ./pgedge set BACKUP repo1-host-user {n['os_user']};
+    ./pgedge set BACKUP pg1-host0 " ";
+    ./pgedge set BACKUP pg1-path0 {s["path"]}/pgedge/data/{stanza};
+    ./pgedge set BACKUP pg1-port0 {s['port']};
+    ./pgedge backrest save-config;
+    '''
+    utilx.echo_cmd(cmd, host=s["ip_address"], usr=s["os_user"], key=s["ssh_key"])
+   
+    if stanza_create:
+        utilx.echo_message(f"Creating stanza {stanza}", bold=True)
+        cmd0 = f"cd {s['path']}/pgedge/;"
+        cmd1 = f"./pgedge backrest create-stanza {stanza} --verbose={verbose};"
+        utilx.echo_cmd(cmd0 + cmd1, host=s["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    
+    if backup_id == " ":
+        utilx.echo_message(f"Creating full backup", bold=True)
+        cmd0 = f"cd {s['path']}/pgedge/;"
+        cmd1 = f"./pgedge backrest backup {stanza} --verbose={verbose};"
+        utilx.echo_cmd(cmd0 + cmd1, host=s["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    
+    utilx.echo_node(n)
+
+    apply_s3_settings("pgedge-s3.conf", path = f"{n['path']}/pgedge/", host=s["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    
+    cmd = f'''
+    cd {n['path']}/pgedge/;
+    ./pgedge install backrest;
+    ./pgedge set BACKUP stanza_count 1;
+    ./pgedge set BACKUP repo1-path /var/lib/pgbackrest/{s["name"]};
+    ./pgedge set BACKUP repo1-cipher-pass pgedge;
+    ./pgedge set BACKUP repo1-host {s["ip_address"]};
+    ./pgedge set BACKUP repo1-host-user {n['os_user']};
+    ./pgedge set BACKUP pg1-host0 " ";
+    ./pgedge set BACKUP pg1-path0 {s["path"]}/pgedge/data/{stanza};
+    ./pgedge set BACKUP pg1-port0 {s['port']};
+    ./pgedge backrest save-config;
+    '''
+
+    utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+
+    utilx.echo_message(f"Creating read replica", bold = True)
+    
+    cmd = f'''
+    cd {n['path']}/pgedge/;
+    ./pgedge backrest create-replica --stanza={stanza} --data_dir={n["path"]}/pgedge/replica/{stanza} --verbose={verbose}
+    '''
+    utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    
+    utilx.echo_message("Stopping/removing default new cluster", bold = True)
+    cmd = f'''
+    cd {n['path']}/pgedge/;
+    ./pgedge stop
+    '''
+    utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+
+    cmd = f'rm -rf {n["path"]}/pgedge/data/{stanza}'
+    utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+
+    print(f"\n# Starting new cluster\n")
+    cmd = f'mv {n["path"]}/pgedge/replica/{stanza} {n["path"]}/pgedge/data/'
+    utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    
+    pgd = f'{n["path"]}/pgedge/data/{stanza}'
+    pgc = f'{pgd}/postgresql.conf'
+    
+    cmd = f'echo "ssl_cert_file=\'{pgd}/server.crt\'" >> {pgc}'
+    utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+
+    cmd = f'echo "ssl_key_file=\'{pgd}/server.key\'" >> {pgc}'
+    utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    
+    cmd = f'echo "log_directory=\'{pgd}/log\'" >> {pgc}'
+    utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    
+    cmd = f'echo "shared_preload_libraries = \'pg_stat_statements, snowflake\'">> {pgc}'
+    utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    
+    utilx.echo_message("Starting new cluster", bold = True)
+    cmd = f'''
+    cd {n['path']}/pgedge/;
+    ./pgedge config pg16 --port={n["port"]};
+    ./pgedge start
+    '''
+    
+    utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+
+    utilx.echo_message("Checking lag time of new cluster", bold = True)
+    cmd = """
+    SELECT
+    pg_last_wal_receive_lsn() AS last_receive_lsn,
+    pg_last_wal_replay_lsn() AS last_replay_lsn,
+    pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn()) AS lag_bytes
+    """
+
+    lag_bytes = 1
+    while True:
+        if lag_bytes == 0:
+            break
+        time.sleep(1)
+        op = util.psql_cmd_output(cmd, f"{n['path']}/pgedge/pgedge", db[0]["name"], stanza, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+        last_receive_lsn, last_replay_lsn, lag_bytes = parse_query_output(op)
+        print(f"Replica is {lag_bytes} bytes behind")
+    
+    terminate_cluster_transaction(nodes, dbname, stanza)
+    set_cluster_readonly(nodes, True, dbname, stanza)
+
+    cmd = "SELECT pg_promote()"
+    util.psql_cmd_output(cmd, f"{n['path']}/pgedge/pgedge", dbname, stanza, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+
+    cmd = "DROP EXTENSION spock CASCADE"
+    util.psql_cmd_output(cmd, f"{n['path']}/pgedge/pgedge", dbname, stanza, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    
+    cmd = f'''
+    cd {n['path']}/pgedge/;
+    ./pgedge install spock33-pg16 -d {dbname}
+    '''
+    utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+   
+    create_node(nodes, n, dbname)
+    set_cluster_readonly(nodes, False,  dbname, stanza)
+    create_sub(nodes, n, dbname)
+    cluster_data['node_groups']['aws'].append(node_data)
+    write_cluster_json(cluster_name, cluster_data)
+
+def create_node(nodes, n, dbname):
+    utilx.echo_action(f"Creating new node {n['name']}")
+    cmd = f'''
+    cd {n['path']}/pgedge/;
+    ./pgedge spock node-create {n["name"]} 'host={n["ip_address"]} user=pgedge dbname={dbname} port={n["port"]}' {dbname}
+    '''
+    utilx.echo_cmd(cmd, host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"])
+    utilx.echo_action(f"Creating new node {n['name']}", "ok")
+
+def create_sub(nodes, n, dbname):
+    for node in nodes:
+        utilx.echo_action(f"Creating sub-create sub_{node['name']}{n['name']}")
+        cmd = f'''
+        cd {node['path']}/pgedge/;
+        ./pgedge spock sub-create sub_{node["name"]}{n["name"]} 'host={n["ip_address"]} user=pgedge dbname={dbname} port={n["port"]}' {dbname}
+        '''
+        util.echo_cmd(cmd, host=node["ip_address"], usr=node["os_user"], key=node["ssh_key"])
+        utilx.echo_action(f"Creating sub-create sub_{node['name']}{n['name']}", "ok")
+
+def terminate_cluster_transaction(nodes, dbname, stanza):
+    utilx.echo_action("Terminating cluster transcations")
+    cmd = """
+    SELECT spock.terminate_active_transactions()
+    """
+    for node in nodes:
+        util.psql_cmd_output(cmd, f"{node['path']}/pgedge/pgedge", dbname, stanza, host=node["ip_address"], usr=node["os_user"], key=node["ssh_key"])
+    utilx.echo_action("Terminating cluster transcations", "ok")
+
+def set_cluster_readonly(nodes, readonly, dbname, stanza):
+    if readonly == True:
+        utilx.echo_action(f"Setting readonly mode from cluster")
+        cmd = """
+        SELECT spock.set_cluster_readonly()
+        """
+        for node in nodes:
+            cwd = f"{node['path']}/pgedge/pgedge"
+            util.psql_cmd_output(cmd, cwd, dbname, stanza,host=node["ip_address"], usr=node["os_user"], key=node["ssh_key"])
+        utilx.echo_action(f"Setting readonly mode from cluster", "ok")
+    else:
+        utilx.echo_action(f"Removing readonly mode from cluster")
+        cmd = """
+        SELECT spock.unset_cluster_readonly()
+        """
+        for node in nodes:
+            cwd = f"{node['path']}/pgedge/pgedge"
+            util.psql_cmd_output(cmd, cwd, dbname, stanza,host=node["ip_address"], usr=node["os_user"], key=node["ssh_key"])
+        utilx.echo_action(f"Removing readonly mode from cluster", "ok")
+
+def parse_query_output(output):
+    # Split the output into lines
+    lines = output.split('\n')
+    
+    # Find the line with the data (usually the third line if formatted as shown)
+    data_line = lines[2].strip()
+    
+    # Split the data line into parts
+    parts = data_line.split('|')
+    
+    # Trim whitespace and assign to variables
+    last_receive_lsn = parts[0].strip()
+    last_replay_lsn = parts[1].strip()
+    lag_bytes = int(parts[2].strip())  # Convert lag_bytes to an integer
+    
+    # Return the parsed values
+    return last_receive_lsn, last_replay_lsn, lag_bytes
+
+def remove_node(cluster_name, node_name):
+    """Remove node from cluster."""
+    
+    cluster_data = get_cluster_json(cluster_name)
+    
+    node_groups = cluster_data.get('node_groups', {})
+    nodes = node_groups.get('aws', [])
+
+    for node_group in nodes:
+        nodes = node_group.get('nodes', [])
+        for node in nodes:
+            if node.get('name') == node_name:
+                nodes.remove(node)
+                break
+
+    write_cluster_json(cluster_name, cluster_data)
 
 if __name__ == "__main__":
     fire.Fire(
@@ -716,6 +1039,9 @@ if __name__ == "__main__":
             "json-template": create_remote_json,
             "json-validate": validate,
             "init": init,
+            "list-nodes": list_nodes,
+            "add-node": add_node,
+            "remove-node": remove_node,
             "replication-begin": replication_all_tables,
             "replication-check": replication_check,
             "add-db": add_db,

--- a/cli/scripts/cluster_util.py
+++ b/cli/scripts/cluster_util.py
@@ -1,0 +1,133 @@
+#  Copyright 2022-2024 PGEDGE  All rights reserved. #
+
+import os, json, datetime
+import util, utilx, fire, meta, time, sys
+
+def create_node(node, dbname):
+    """
+    Creates a new node in the database cluster.
+    """
+    utilx.echo_action(f"Creating new node {node['name']}")
+
+    cmd = (f"cd {node['path']}/pgedge/; "
+           f"./pgedge spock node-create {node['name']} "
+           f"'host={node['ip_address']} user=pgedge dbname={dbname} "
+           f"port={node['port']}' {dbname}")
+    utilx.echo_cmd(cmd, host=node["ip_address"],
+                   usr=node["os_user"], key=node["ssh_key"])
+    utilx.echo_action(f"Creating new node {node['name']}", "ok")
+
+def create_sub(nodes, new_node, dbname):
+    """
+    Creates subscriptions for each node to a new node in the cluster.
+    """
+    for node in nodes:
+        sub_name = f"sub_{node['name']}{new_node['name']}"
+        utilx.echo_action(f"Creating subscription {sub_name}")
+
+        cmd = (f"cd {node['path']}/pgedge/; "
+               f"./pgedge spock sub-create {sub_name} "
+               f"'host={new_node['ip_address']} user=pgedge dbname={dbname} "
+               f"port={new_node['port']}' {dbname}")
+        utilx.echo_cmd(cmd, host=node["ip_address"],
+                       usr=node["os_user"], key=node["ssh_key"])
+        utilx.echo_action(f"Subscription {sub_name} created successfully", "ok")
+
+def terminate_cluster_transactions(nodes, dbname, stanza):
+    """
+    Terminates active transactions across the cluster.
+    """
+    utilx.echo_action("Terminating cluster transactions")
+
+    cmd = "SELECT spock.terminate_active_transactions();"
+    for node in nodes:
+        util.psql_cmd_output(cmd, f"{node['path']}/pgedge/pgedge", dbname,
+                              stanza, host=node["ip_address"],
+                              usr=node["os_user"], key=node["ssh_key"])
+    utilx.echo_action("Cluster transactions terminated successfully", "ok")
+
+def set_cluster_readonly(nodes, readonly, dbname, stanza):
+    """
+    Sets or unsets readonly mode on a PostgreSQL cluster across multiple nodes.
+    """
+    action = "Setting" if readonly else "Removing"
+    func_call = ("spock.set_cluster_readonly()" if readonly
+                 else "spock.unset_cluster_readonly()")
+
+    utilx.echo_action(f"{action} readonly mode from cluster")
+
+    cmd = f"SELECT {func_call};"
+
+    for node in nodes:
+        util.psql_cmd_output(cmd, f"{node['path']}/pgedge/pgedge", dbname,
+                              stanza, host=node["ip_address"],
+                              usr=node["os_user"], key=node["ssh_key"])
+    utilx.echo_action(f"{action} readonly mode from cluster", "ok")
+
+def check_cluster_lag(n, dbname, stanza):
+    """
+    Monitors the replication lag of a new cluster node until it catches up.
+    """
+    utilx.echo_action("Checking lag time of new cluster")
+
+    cmd = """
+    SELECT
+        pg_last_wal_receive_lsn() AS last_receive_lsn,
+        pg_last_wal_replay_lsn() AS last_replay_lsn,
+        pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn()) 
+            AS lag_bytes
+    """
+
+    lag_bytes = 1
+    while lag_bytes > 0:
+        time.sleep(1)
+        op = util.psql_cmd_output(
+            cmd, f"{n['path']}/pgedge/pgedge", dbname, stanza,
+            host=n["ip_address"], usr=n["os_user"], key=n["ssh_key"]
+        )
+        last_receive_lsn, last_replay_lsn, lag_bytes = parse_query_output(op)
+    utilx.echo_action("Checking lag time of new cluster", "ok")
+
+def manage_node(node, action):
+    """
+    Starts or stops a cluster based on the provided action.
+    """
+    if action not in ['start', 'stop']:
+        raise ValueError("Invalid action. Use 'start' or 'stop'.")
+
+    action_message = "Starting" if action == 'start' else "Stopping"
+    utilx.echo_action(f"{action_message} new node")
+
+    # Construct the command based on the action
+    if action == 'start':
+        cmd = (f"cd {node['path']}/pgedge/; "
+               f"./pgedge config pg16 --port={node['port']}; "
+               f"./pgedge start")
+    else:
+        cmd = (f"cd {node['path']}/pgedge/; "
+               f"./pgedge stop")
+
+    # Execute the command
+    utilx.echo_cmd(cmd, host=node["ip_address"], usr=node["os_user"], 
+                   key=node["ssh_key"])
+    utilx.echo_action(f"{action_message} new node", "ok")
+
+
+def parse_query_output(output):
+    # Split the output into lines
+    lines = output.split('\n')
+    
+    # Find the line with the data (usually the third line if formatted as shown)
+    data_line = lines[2].strip()
+    
+    # Split the data line into parts
+    parts = data_line.split('|')
+    
+    # Trim whitespace and assign to variables
+    last_receive_lsn = parts[0].strip()
+    last_replay_lsn = parts[1].strip()
+    lag_bytes = int(parts[2].strip())  # Convert lag_bytes to an integer
+    
+    # Return the parsed values
+    return last_receive_lsn, last_replay_lsn, lag_bytes
+

--- a/cli/scripts/contrib/localhost.py
+++ b/cli/scripts/contrib/localhost.py
@@ -231,7 +231,7 @@ Below is an example of the JSON file that is generated that defines a 2 node loc
     create_local_json(cluster_name, db, num_nodes, User, Passwd, pg, port1, auto_ddl)
     db, db_settings, nodes = cluster.load_json(cluster_name)
 
-    cluster.ssh_install_pgedge(cluster_name, db[0]["name"], db_settings, db[0]["username"], db[0]["password"], nodes)
+    cluster.ssh_install_pgedge_all(cluster_name, db[0]["name"], db_settings, db[0]["username"], db[0]["password"], nodes)
     cluster.ssh_cross_wire_pgedge(cluster_name, db[0]["name"], db_settings, db[0]["username"], db[0]["password"], nodes)
     if len(db) > 1:
         for database in db[1:]:

--- a/cli/scripts/utilx.py
+++ b/cli/scripts/utilx.py
@@ -18,16 +18,21 @@ import sys
 
 bold_start = "\033[1m"
 bold_end = "\033[0m"
+
 def echo_action(action, status=None, e=False):
+
+    now = datetime.now()
+    t = now.strftime('%B %d, %Y, %H:%M:%S')
+    
     if status is None:
-        sys.stdout.write(f"{action}... ")
+        sys.stdout.write(f"{t}: {action}... ")
         sys.stdout.flush()
     else:
         sys.stdout.write("\r")
         if status.lower() == "ok":
-            sys.stdout.write(f"{action}... [OK]\n")
+            sys.stdout.write(f"{t}: {action}... [OK]\n")
         else:
-            sys.stdout.write(f"{action}... [Failed]\n")
+            sys.stdout.write(f"{t}: {action}... [Failed]\n")
             if e == True:
                 exit(1)
         sys.stdout.flush()

--- a/cli/scripts/utilx.py
+++ b/cli/scripts/utilx.py
@@ -14,23 +14,97 @@ from dateutil import parser
 from datetime import datetime
 import logging
 
-def run_command(command_args, max_attempts=1, timeout=None, capture_output=False, env=None, cwd=None, verbose=True):
-    """
-    Executes an external command, with options to retry, set timeout, and capture output.
+import sys
 
-    Args:
-        command_args (list): Command and its arguments as a list, e.g., ['ls', '-l'].
-        max_attempts (int): Maximum number of attempts to execute the command.
-        timeout (int, optional): Time in seconds to wait for the command to complete.
-        capture_output (bool): Whether to capture and return the command's output.
-        env (dict, optional): Environment variables to set for the command.
-        cwd (str, optional): Set the working directory for the command.
-        verbose (bool): Print detailed execution logs.
+bold_start = "\033[1m"
+bold_end = "\033[0m"
+def echo_action(action, status=None, e=False):
+    if status is None:
+        sys.stdout.write(f"{action}... ")
+        sys.stdout.flush()
+    else:
+        sys.stdout.write("\r")
+        if status.lower() == "ok":
+            sys.stdout.write(f"{action}... [OK]\n")
+        else:
+            sys.stdout.write(f"{action}... [Failed]\n")
+            if e == True:
+                exit(1)
+        sys.stdout.flush()
 
-    Returns:
-        dict: A dictionary with keys 'success', 'output', 'error', and 'attempts',
-              indicating the execution status, captured output, error message, and number of attempts.
-    """
+def echo_message(msg, bold=False, level="info"):
+    now = datetime.now()
+    t = now.strftime('%B %d, %Y, %H:%M:%S')
+
+    if bold == True:
+        util.message(t + ": " + bold_start + msg + bold_end, level)
+    else:
+        util.message(t + ": " + msg,level)
+
+    if level == "error":
+        exit(1)
+
+def echo_node(data):
+    nodes = data.get('nodes', [])
+    for node in nodes:
+        print('#' * 30)
+        for key, value in node.items():
+            print(bold_start + f"* {key}:" + bold_end +"{value}")
+        print(bold_start + '#'*30 + bold_end)
+
+def echo_cmd(cmd, echo=False, sleep_secs=0, host="", usr="", key=""):
+    if host > "":
+        ssh_cmd = "ssh -o StrictHostKeyChecking=no -q -t "
+        if usr > "":
+            ssh_cmd = ssh_cmd + str(usr) + "@"
+
+        ssh_cmd = ssh_cmd + str(host) + " "
+
+        if key > "":
+            ssh_cmd = ssh_cmd + "-i " + str(key) + " "
+
+        cmd = cmd.replace('"', '\\"')
+
+        if os.getenv("pgeDebug", "") > "":
+            cmd = f"{cmd} --debug"
+
+        cmd = ssh_cmd + ' "' + str(cmd) + '"'
+
+    isSilent = os.getenv("isSilent", "False")
+    if isSilent == "False":
+        s_cmd = scrub_passwd(cmd)
+        if echo:
+            print("#  " + str(s_cmd))
+
+    rc = os.system(str(cmd))
+    if rc == 0:
+        if int(sleep_secs) > 0:
+            os.system("sleep " + str(sleep_secs))
+        return 0
+
+    return 1
+
+def scrub_passwd(p_cmd):
+    ll = p_cmd.split()
+    flag = False
+    new_s = ""
+    key_wd = ""
+
+    for i in ll:
+        if ((i == "PASSWORD") or (i == "-P")) and (flag is False):
+            flag = True
+            key_wd = str(i)
+            continue
+
+        if flag:
+            new_s = new_s + " " + key_wd + " '???'"
+            flag = False
+        else:
+            new_s = new_s + " " + i
+
+    return new_s
+
+def run_command(command_args, max_attempts=1, timeout=None, capture_output=True, env=None, cwd=None, verbose=False):
     attempts = 0
     output, error = "", ""
 
@@ -44,13 +118,13 @@ def run_command(command_args, max_attempts=1, timeout=None, capture_output=False
                 output = result.stdout
                 error = result.stderr
             if verbose:
-                print(f"Attempt {attempts}: Command executed successfully.")
+                print(f"Command executed successfully.")
             return {"success": True, "output": output, "error": error, "attempts": attempts}
 
         except subprocess.CalledProcessError as e:
             error = e.stderr if capture_output else str(e)
             if verbose:
-                print(f"Attempt {attempts}: Error executing command: {error}")
+                print(f"Error executing command: {error}")
             time.sleep(1)  # Simple backoff strategy
         except subprocess.TimeoutExpired as e:
             error = f"Command timed out after {timeout} seconds."
@@ -59,7 +133,6 @@ def run_command(command_args, max_attempts=1, timeout=None, capture_output=False
             break  # No retry after timeout
 
     return {"success": False, "output": output, "error": error, "attempts": attempts}
-
 
 def check_directory_status(directory_path):
     """
@@ -109,123 +182,38 @@ def check_directory_status(directory_path):
 
 
 def sfmt_time(date_string, target_timezone='UTC'):
-    """
-    Formats a given date string to 'YYYY-MM-DD HH:MM:SS' format including timezone conversion.
-
-    Args:
-        date_string (str): The date string to format.
-        target_timezone (str): The target timezone for the formatted datetime. Defaults to 'UTC'.
-
-    Returns:
-        str: Formatted datetime string with timezone.
-
-    Raises:
-        ValueError: If the input date string is in an invalid format.
-    """
     try:
-        # Use dateutil.parser to automatically parse the date string
         dt = parser.parse(date_string)
-
-        # Check if the datetime object is timezone-aware. If not, assume UTC.
         if dt.tzinfo is None:
             from datetime import timezone
             dt = dt.replace(tzinfo=timezone.utc)
 
-        # Convert to target timezone if necessary
         if target_timezone.upper() != 'UTC':
             from zoneinfo import ZoneInfo
             dt = dt.astimezone(ZoneInfo(target_timezone))
 
-        # Format the datetime object to the required format with timezone information
         formatted_time_with_timezone = dt.strftime("%Y-%m-%d %H:%M:%S")
-        #formatted_time_with_timezone = dt.strftime("%Y-%m-%d %H:%M:%S %Z")
 
         return formatted_time_with_timezone
 
     except ValueError as e:
         raise ValueError(f"Invalid date string format: {e}")
 
-# Setup the logger
-logger = logging.getLogger('')
-logger.setLevel(logging.DEBUG)  # This could be configurable
-
-# Create console handler and set level to debug
-ch = logging.StreamHandler()
-ch.setLevel(logging.DEBUG)
-
-# Create formatter
-formatter = logging.Formatter('%(levelname)s - %(message)s')
-
-# Add formatter to ch
-ch.setFormatter(formatter)
-
-# Add ch to logger
-logger.addHandler(ch)
-
-
-def ereport(severity, message, detail=None, hint=None, context=None):
-    """
-    Mimics PostgreSQL's ereport function for logging messages in a style that closely resembles PostgreSQL log format.
-
-    Args:
-        severity (str): The severity level ('ERROR', 'WARNING', 'NOTICE', 'DEBUG', etc.).
-        message (str): The primary human-readable error message.
-        detail (str, optional): An optional detail message providing more context.
-        hint (str, optional): An optional hint message suggesting how to fix the problem.
-        context (str, optional): An optional context message where the error occurred.
-    """
-    parts = [f"{message}"]
-    if detail:
-        parts.append(f" |\tDETAIL: {detail}")
-    if hint:
-        parts.append(f" |\tHINT: {hint}")
-    if context:
-        parts.append(f" |\tCONTEXT: {context}")
-
-    full_message = "\n".join(parts)
-
-    # Assuming logger is already configured
-    if severity.upper() == 'ERROR':
-        logger.error(full_message)
-    elif severity.upper() == 'WARNING':
-        logger.warning(full_message)
-    elif severity.upper() == 'NOTICE':
-        logger.info(full_message)  # NOTICE is mapped to INFO in logging
-    elif severity.upper() == 'DEBUG':
-        logger.debug(full_message)
-    else:
-        logger.info(full_message)  # Default to INFO for unrecognized severity levels
-
 def guc_set(guc_name, guc_value, pg=None):
-    """
-    Sets a PostgreSQL GUC (Grand Unified Configuration) parameter.
-
-    Args:
-        guc_name (str): The name of the GUC parameter to set.
-        guc_value (str): The value to set for the GUC parameter.
-        pg (str, optional): The PostgreSQL version. If not provided, uses a default or derives it.
-    """
     if pg is None:
-        # If pg version is not specified, obtain it using util.get_pg_v function
         pg_v = util.get_pg_v(pg)
-        pg = pg_v[2:]  # Assuming util.get_pg_v returns a version string with a prefix to trim
+        pg = pg_v[2:]
 
-    # Base command prefix for using the appropriate PostgreSQL binary
     cmd_prefix = f"./pgedge pgbin {pg} "
 
-    # Command to alter the system setting for the specified GUC
     alter_system_cmd = f'psql -q -c "ALTER SYSTEM SET {guc_name} = {guc_value}" postgres'
 
-    # Execute the ALTER SYSTEM command
     rc1 = util.echo_cmd(f'{cmd_prefix}"{alter_system_cmd}"', False)
 
-    # Command to reload the configuration to apply the change
     reload_conf_cmd = 'psql -q -c "SELECT pg_reload_conf()" postgres'
 
-    # Execute the RELOAD CONFIGURATION command
     rc2 = util.echo_cmd(f'{cmd_prefix}"{reload_conf_cmd}"', False)
 
-    # Check if both commands executed successfully
     if rc1 == 0 and rc2 == 0:
         util.message(f"Set GUC {guc_name} to {guc_value}", "info")
     else:

--- a/src/backrest/backrest.py
+++ b/src/backrest/backrest.py
@@ -1,367 +1,354 @@
 #!/usr/bin/env python3
-#     Copyright (c)  2022-2024 PGEDGE  #
 import subprocess
 import os
 import fire
 import util
+import time
 import utilx
 import json
 import sys
 from datetime import datetime
 from tabulate import tabulate
 
+thisDir = os.path.dirname(os.path.realpath(__file__))
+
+def pgV():
+    """Return the first found among supported PostgreSQL versions."""
+    pg_versions = ["pg14", "pg15", "pg16"]
+    for pg_version in pg_versions:
+        if os.path.isdir(pg_version):
+            return pg_version
+    sys.exit("pg14, 15 or 16 must be installed")
+
 def osSys(p_input, p_display=True):
+    """Execute a shell command and optionally display it."""
     if p_display:
         util.message("# " + p_input)
-    rc = os.system(p_input)
-    return rc
-
+    return os.system(p_input)
 
 def fetch_backup_config():
-    """Fetch backup configuration from util module or other configuration source."""
+    """Fetch and return the pgbackrest configuration from system settings."""
     config = {
-        "BACKUP_TOOL": util.get_value("BACKUP", "BACKUP_TOOL"),
-        "STANZA": util.get_value("BACKUP", "STANZA"),
-        "DATABASE": util.get_value("BACKUP", "DATABASE"),
-        "PG_PATH": util.get_value("BACKUP", "PG_PATH"),
-        "PG_SOCKET_PATH": util.get_value("BACKUP", "PG_SOCKET_PATH"),
-        "PG_USER": util.get_value("BACKUP", "PG_USER"),
-        "REPO_CIPHER_TYPE": util.get_value("BACKUP", "REPO_CIPHER_TYPE"),
-        "REPO_PATH": util.get_value("BACKUP", "REPO_PATH"),
-        "REPO_RETENTION_FULL_TYPE": util.get_value("BACKUP", "REPO_RETENTION_FULL_TYPE"),
-        "REPO_RETENTION_FULL": util.get_value("BACKUP", "REPO_RETENTION_FULL"),
-        "PRIMARY_HOST": util.get_value("BACKUP", "PRIMARY_HOST"),
-        "PRIMARY_PORT": util.get_value("BACKUP", "PRIMARY_PORT"),
-        "PRIMARY_USER": util.get_value("BACKUP", "PRIMARY_USER"),
-        "REPLICA_PASSWORD": util.get_value("BACKUP", "REPLICA_PASSWORD"),
-        "RECOVERY_TARGET_TIME": util.get_value("BACKUP", "RECOVERY_TARGET_TIME"),
-        "PROCESS_MAX": util.get_value("BACKUP", "PROCESS_MAX"),
-        "RESTORE_PATH": util.get_value("BACKUP", "RESTORE_PATH"),
-
-        "REPO1_TYPE": util.get_value("BACKUP", "REPO1_TYPE"),
-
-        "REPO_PATH": util.get_value("BACKUP", "REPO_PATH"),
-        "PG_PATH": util.get_value("BACKUP", "PG_PATH"),
-        "BACKUP_TYPE": util.get_value("BACKUP", "BACKUP_TYPE"),
-
-        "S3_BUCKET": util.get_value("BACKUP", "S3_BUCKET"),
-        "S3_REGION": util.get_value("BACKUP", "S3_REGION"),
-        "S3_ENDPOINT": util.get_value("BACKUP", "S3_ENDPOINT"),
+        "main": {},
+        "global": {},
+        "stanza": {}
     }
+
+    main_params = ["restore_path", "backup-type", "stanza_count"]
+    global_params = [
+        "repo1-retention-full", "repo1-retention-full-type", "repo1-path", "repo1-host-user", "repo1-host",
+        "repo1-cipher-type", "repo1-cipher-pass", "repo1-s3-bucket", "repo1-s3-key-secret", "repo1-s3-key",
+        "repo1-s3-region", "repo1-s3-endpoint", "log-level-console", "repo1-type",
+        "process-max", "compress-level"
+    ]
+    stanza_params = [
+        "pg1-path", "pg1-user", "pg1-database", "db-socket-path", "pg1-port", "pg1-host"
+    ]
+
+    # Fetch main and global parameters
+    for param in main_params:
+        config["main"][param] = util.get_value("BACKUP", param)
+    for param in global_params:
+        config["global"][param] = util.get_value("BACKUP", param)
+
+    # Determine the number of stanzas and fetch their specific parameters
+    stanza_count = int(config["main"].get("stanza_count", 1))
+    for i in range(stanza_count):
+        stanza_name = util.get_value("BACKUP", f"stanza{i}")
+        config["stanza"][stanza_name] = {}
+        for param in stanza_params:
+            indexed_param = f"{param}{i}"
+            config["stanza"][stanza_name][param] = util.get_value("BACKUP", indexed_param)
+
     return config
 
-def backup(type="full"):
-    """
-    Backup a database cluster.
+def show_config():
+    """Display the current configuration in a readable format."""
+    config = fetch_backup_config()  # Fetches the full configuration from wherever it's stored
+    max_key_length = max(max(len(key) for key in section) for section in config.values() if section)
 
-    :param type: Specifies the type of backup to perform. This should be one of the following options:
+    # Print section with adequate formatting based on the maximum key length
+    print("#" * (max_key_length + 40))
 
-                 * "full" - Performs a full backup.
+    main  = config["main"]
+    print(f"[main]")
+    for key, value in main.items():
+        print(f"{key.ljust(max_key_length + 1)}= {value}")
 
-                 * "diff" - Performs a differential backup.
+    glob = config["global"]
+    print(f"[global]")
+    for key, value in glob.items():
+        print(f"{key.ljust(max_key_length + 1)}= {value}")
 
-                 * "incr" - Performs an incremental backup.
+    stanza_count = int(config["main"].get("stanza_count", 1))
+    for i in range(stanza_count):
+        stanza_name = util.get_value("BACKUP", f"stanza{i}")
+        print(f"[{stanza_name}]")
+        for key, value in config["stanza"][stanza_name].items():
+            clean_key = key.replace(str(i), '') 
+            print(f"{clean_key.ljust(max_key_length + 1)}= {value}")
+    
+    print("#" * (max_key_length + 40))
 
-    :type type: str
-    :return: None
-    """
 
+def save_config(filename="pgbackrest.conf"):
+    """Save the current pgbackrest configuration to a file in standard format."""
     config = fetch_backup_config()
-    allowed_types = ["full", "diff", "incr"]
-    if type not in allowed_types:
-        util.message(f"Error: '{type}' is not a valid backup type. Allowed types are: {', '.join(allowed_types)}.")
+    lines = []
+
+    # Write global settings
+    if config["global"]:
+        lines.append("[global]")
+        for key, value in config["global"].items():
+            if key == "compress-level":
+                continue  # Handle this key separately in its own section
+            if value != " ":
+                lines.append(f"{key} = {value}")
+        lines.append("")  # Add a newline for separation
+
+        # Handle global:archive-push specifically if needed
+        if "compress-level" in config["global"]:
+            lines.append("[global:archive-push]")
+            lines.append(f"compress-level = {config['global']['compress-level']}")
+            lines.append("")  # Add a newline for separation
+
+    # Write stanza sections
+    stanza_count = int(config["main"].get("stanza_count", 1))
+    for i in range(stanza_count):
+        stanza_name = util.get_value("BACKUP", f"stanza{i}")
+        if stanza_name in config["stanza"]:
+            lines.append(f"[{stanza_name}]")
+            for key, value in config["stanza"][stanza_name].items():
+                clean_key = key.replace(str(i), '')  # Remove the index from key names
+                if value != " ":
+                    lines.append(f"{clean_key} = {value}")
+            lines.append("")  # Add a newline for separation
+
+    # Write the configuration to file
+    with open(f"{thisDir}/{filename}", "w") as f:
+        f.write("\n".join(lines))
+    util.message(f"Configuration saved to {thisDir}/{filename}.")
+    osSys(f"sudo cp {thisDir}/{filename} /etc/pgbackrest/")
+
+    return filename
+
+def backup(stanza, type="full", verbose=True):
+    """Perform a backup of a database cluster.
+
+    Args:
+        stanza (str): The name of the stanza to perform the backup on.
+        type (str): The type of backup to perform. Defaults to "full".
+                    Allowed types are "full", "diff", and "incr".
+    """
+    config = fetch_backup_config()
+    valid_types = ["full", "diff", "incr"]
+    if type not in valid_types:
+        utilx.echo_message(f"Error: '{type}' is not a valid backup type.\n allowed types are: {', '.join(valid_types)}.", level = "error")
         return
 
-    command = [
-        config["BACKUP_TOOL"], "--type", type, "backup",
-        "--stanza", config["STANZA"],
-        "--pg1-path", config["PG_PATH"],
-        "--start-fast",
-        "--process-max", config["PROCESS_MAX"],
-        #"--pg1-host", config["PRIMARY_HOST"],
-        "--pg1-port", config["PRIMARY_PORT"],
-        "--repo1-retention-full-type", config["REPO_RETENTION_FULL_TYPE"],
-        "--repo1-retention-full", config["REPO_RETENTION_FULL"],
-    ]
+    command = ["pgbackrest", "--stanza", stanza, "--type", type, "backup"]
 
-    # Adding repository type specific configurations
-    if config["REPO1_TYPE"] == "s3":
-        command.extend([
-            "--repo1-type", "s3",
-            "--repo1-s3-bucket", config["S3_BUCKET"],
-            "--repo1-s3-region", config["S3_REGION"],
-            "--repo1-s3-endpoint", config["S3_ENDPOINT"],
-        ])
-    elif config["REPO1_TYPE"] == "posix":
-        command.extend(["--repo1-path", config["REPO_PATH"]])
+    result = utilx.run_command(command, capture_output = not verbose)
+    if result["success"] == False:
+        utilx.echo_message(f"Error: failed to take {type} backup", level = "error")
 
-    utilx.run_command(command)
-
-def restore(backup_label=None, recovery_target_time=None):
-    """
-    Restore a database cluster.
-
-    :param backup_label: The backup label to use for creating the replica. If not specified, the latest backup will be used.
-    :type backup_label: str, optional
-
-    :param recovery_target_time: The target time for point-in-time recovery (PITR). This allows the replica to be restored to a specific point in time, rather than the state at the time of the backup.
-    :type recovery_target_time: str, optional.
-
-    :return: None
-    """
-    pass
-
+def restore(stanza, data_dir=None, backup_label=None, recovery_target_time=None, verbose=True):
+    """Restore a database cluster to a specified state."""
+    
     config = fetch_backup_config()
-    rpath = config["RESTORE_PATH"]
-    data_dir = rpath + "/data/"
+    if data_dir == None:
+        data_dir = os.path.join(config["main"]["restore_path"], stanza, "data")
 
-    print("Checking restore path directory and permissions ...")
-    status = utilx.check_directory_status(rpath)
-    if status['exists'] == True:
-        if status['writable'] != True:
-            util.message(status['message'])
-            return
+    status = utilx.check_directory_status(data_dir)
+    if status['exists'] and not status['writable']:
+        util.message(status['message'])
+        return
 
-    # Construct the restore command
-    command = [
-        config["BACKUP_TOOL"],
-        "restore",
-        "--stanza", config["STANZA"],
-        "--pg1-path", data_dir
-    ]
+    command = ["pgbackrest", "--stanza", stanza, "restore", "--pg1-path", data_dir]
 
-    # Append --delta if the directory existed and is writable
-    if status['exists'] == True:
+    if status['exists']:
         command.append("--delta")
+    
+    if backup_label:
+        command.append(f"--set={backup_label}")
 
-    # Extend command based on `backup_label` and `recovery_target_time`
-    if config["BACKUP_TOOL"] == "pgbackrest":
-        if backup_label:
-            command.append("--set={}".format(backup_label))
-        if recovery_target_time:
-            formatted_time = utilx.sfmt_time(recovery_target_time)
-            command.append(f"--type=time")
-            command.append(f"--target={formatted_time}")
+    if recovery_target_time:
+        command.append("--type=time")
+        command.append(f"--target={recovery_target_time}")
 
-    result = utilx.run_command(command)
-    if result["success"]:
-        util.message("Restoration completed successfully.")
-        #print("Output:", result["output"])
-    else:
-        utilx.ereport('Error', 'Failed to restore cluster',
-        detail='Ensure the PostgreSQL instance is not running on that restore path',
-        context='Restore Cluster')
-        exit(1)
-    return result
+    result = utilx.run_command(command, capture_output = not verbose)
+    if result["success"] == False:
+        utilx.echo_message(f"Error: failed to restore backup", level = "error")
+    return True
 
-def _configure_pitr(stanza, recovery_target_time=None):
+def pitr(stanza, data_dir=None, recovery_target_time=None, verbose=True):
+    """Perform point-in-time recovery on a database cluster."""
+    if restore(stanza, data_dir=None, backup_label = None, recovery_target_time=recovery_target_time, verbose=verbose) == True:
+        _configure_pitr(stanza, data_dir, recovery_target_time)
+
+def _configure_pitr(stanza, pg_data_dir=None, recovery_target_time=None):
+    """Configure PostgreSQL for point-in-time recovery."""
     config = fetch_backup_config()
-    conf_file = os.path.join(config["RESTORE_PATH"], "data/postgresql.conf")
-    logDir= config["RESTORE_PATH"] + "/log/"
-    change_pgconf_keyval(conf_file, "port", "5433")
-    change_pgconf_keyval(conf_file, "log_directory", logDir)
-    change_pgconf_keyval(conf_file, "archive_command", "")
-    change_pgconf_keyval(conf_file, "archive_mode", "off")
-    change_pgconf_keyval(conf_file, "hot_standby", "on")
-    change_pgconf_keyval(conf_file, "recovery_target_action", "promote",)
+    if pg_data_dir == None:
+        pg_data_dir = os.path.join(config["main"]["restore_path"], stanza, "data")
+
+    if recovery_target_time is None:
+        recovery_target_time = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+    config_file = os.path.join(pg_data_dir, "postgresql.conf")
+
+    # Configuration changes for PITR
+    changes = {
+        "port": "5433",
+        "log_directory": os.path.join(pg_data_dir, "log"),
+        "archive_command": "",
+        "archive_mode": "off",
+        "hot_standby": "on",
+        "recovery_target_time": recovery_target_time,
+        "recovery_target_action": "promote"
+    }
+
+    for key, value in changes.items():
+        change_pgconf_keyval(config_file, key, value)
 
 def change_pgconf_keyval(config_path, key, value):
+    """Edit a key-value pair in the PostgreSQL configuration file."""
     key_found = False
-    new_lines = []
     with open(config_path, 'r') as file:
         lines = file.readlines()
+    with open(config_path, 'w') as file:
         for line in lines:
-            # Check if the line starts with the key
             if line.strip().startswith(key):
-                new_lines.append(f"{key} = '{value}'\n")
+                file.write(f"{key} = '{value}'\n")
                 key_found = True
             else:
-                new_lines.append(line)
-    if not key_found:
-        new_lines.append(f"{key} = '{value}'\n")
+                file.write(line)
+        if not key_found:
+            file.write(f"{key} = '{value}'\n")
 
-    with open(config_path, 'w') as file:
-        file.writelines(new_lines)
+def create_replica(stanza, data_dir=None, backup_label=None, verbose=True):
+    """Create a replica by restoring from a backup and configure it as a standby server."""
+    if restore(stanza, data_dir, backup_label, recovery_target_time=None, verbose=verbose) == True:
+        _configure_replica(stanza, data_dir, verbose)
 
-def _configure_replica():
+def _configure_replica(stanza, pg_data_dir=None, verbose=True):
+    """Configure PostgreSQL to run as a replica (standby server)."""
     config = fetch_backup_config()
-    stanza = config["STANZA"]
-    conf_file = os.path.join(config["RESTORE_PATH"] + "/data/", "postgresql.conf")
-    standby_signal_path = os.path.join(config["RESTORE_PATH"] + "/data/", "standby.signal")
-    logDir= config["RESTORE_PATH"] + "/log/"
-    # Connection info for the primary server
-    primary_conninfo = f"host={config['PRIMARY_HOST']} port={config['PRIMARY_PORT']} user={config['PRIMARY_USER']} password={config['REPLICA_PASSWORD']}"
 
-    change_pgconf_keyval(conf_file, "primary_conninfo", primary_conninfo)
-    change_pgconf_keyval(conf_file, "hot_standby", "on")
-    change_pgconf_keyval(conf_file, "port", "5433")
-    change_pgconf_keyval(conf_file, "log_directory", logDir)
-    change_pgconf_keyval(conf_file, "archive_command", "")
-    change_pgconf_keyval(conf_file, "archive_mode", "off")
+    if pg_data_dir == None:
+        pg_data_dir = os.path.join(config["main"]["restore_path"], stanza, "data")
+    
+    conf_file = os.path.join(pg_data_dir, "postgresql.conf")
+    standby_signal = os.path.join(pg_data_dir, "standby.signal")
 
-    with open(standby_signal_path, "w") as _:
-        pass
+    # Connection info for the primary server should be configured prior to calling this function
+    primary_conninfo = f"host={config['global']['repo1-host']} port={config['stanza'][stanza]['pg1-port']} user={config['stanza'][stanza]['pg1-user']}"
+   
+    # Configure postgresql.conf for replica
+    changes = {
+        "hot_standby": "on",
+        "primary_conninfo": primary_conninfo,
+        "port": f"{config['stanza'][stanza]['pg1-port']}",
+        "log_directory": os.path.join(pg_data_dir, "log"),
+        "archive_command": "cd .",
+        "archive_mode": "on"
+    }
 
-    utilx.ereport('WARNING', 'Configurations modified to configure as replica',
-            detail='Ensure the PostgreSQL instance is restarted to apply these changes.',
-            hint='./pgedge restart',
-            context='Create Replica')
-
-
-def pitr(backup_label=None, recovery_target_time=None):
-    """
-    Perfomr point-in-time recovery.
-
-    :param backup_label: The backup label to use for creating the replica. If not specified, the latest backup will be used.
-    :type backup_label: str, optional
-
-    :param recovery_target_time: The target time for point-in-time recovery (PITR). This allows the replica to be restored to a specific point in time, rather than the state at the time of the backup.
-    :type recovery_target_time: str, optional.
-
-    :return: None
-    """
-    pass
-
-    rtt = utilx.sfmt_time(recovery_target_time)
-    config = fetch_backup_config()
-    result = restore(backup_label, recovery_target_time)
-    if result["success"]:
-        _configure_pitr(config["STANZA"], recovery_target_time)
-
-def create_replica(backup_label=None, recovery_target_time=None, do_backup=False):
-    """
-    Create a replica by restoring from a backup and configure it.
-
-    :param backup_label: The backup label to use for creating the replica. If not specified, the latest backup will be used.
-    :type backup_label: str, optional
-
-    :param recovery_target_time: The target time for point-in-time recovery (PITR). This allows the replica to be restored to a specific point in time, rather than the state at the time of the backup.
-    :type recovery_target_time: str, optional
-
-    :param do_backup: Whether to initiate a new backup before creating the replica. This can be used to ensure that the replica is as up-to-date as possible by creating a fresh backup from the primary before beginning the restoration process.
-    :type do_backup: bool, optional
-
-    :return: None
-    """
-    pass
-
-    # If do_backup is True, initiate a backup before proceeding
-    if do_backup:
-      backup("full")
-
-    restore(backup_label, recovery_target_time)
-
-    # Configure the PostgreSQL instance as a replica
-    _configure_replica()
+    for key, value in changes.items():
+        change_pgconf_keyval(conf_file, key, value)
+    
+    # Create an empty standby.signal file to trigger standby mode
+    open(standby_signal, 'a').close()
 
 def list_backups():
-    """
-    List backups using the configured backup tool.
-    """
-    config = fetch_backup_config()
-    if config["BACKUP_TOOL"] == "pgbackrest":
-        try:
-            # Execute the pgbackrest info command with JSON output format
-            command_output = subprocess.check_output([config["BACKUP_TOOL"], "info", "--output=json"],
-                                                     stderr=subprocess.STDOUT, universal_newlines=True)
-            backups_info = json.loads(command_output)
-
-            # Prepare table data from backups info
-            backup_table = []
-            for stanza_info in backups_info:
-                for backup in stanza_info.get('backup', []):
-                    backup_details = [
-                        stanza_info['name'],  # Stanza Name
-                        backup.get('label', 'N/A'),  # Backup Label
-                        datetime.utcfromtimestamp(backup['timestamp']['start']).strftime('%Y-%m-%d %H:%M:%S'),  # Start Time
-                        datetime.utcfromtimestamp(backup['timestamp']['stop']).strftime('%Y-%m-%d %H:%M:%S'),  # End Time
-                        backup.get('lsn', {}).get('start', 'N/A'),  # WAL Start
-                        backup.get('lsn', {}).get('stop', 'N/A'),  # WAL End
-                        backup.get('type', 'N/A'),  # Backup Type
-                        f"{backup.get('info', {}).get('size', 0) / (1024**3):.2f} GB"  # Backup Size in GB
-                    ]
-                    backup_table.append(backup_details)
-
-            # Print the backup table
-            headers = ["Stanza Name", "Label", "Start Time", "End Time", "WAL Start", "WAL End", "Backup Type", "Size (GB)"]
-            print(tabulate(backup_table, headers=headers, tablefmt="grid"))
-
-        except subprocess.CalledProcessError as e:
-            util.message(f"Error executing {config['BACKUP_TOOL']} info command:", e.output)
-        except KeyError as ke:
-            util.message(f"Error processing JSON data from {config['BACKUP_TOOL']}:", ke)
-    else:
-        util.message(f"The backup tool '{config['BACKUP_TOOL']}' does not support listing backups through this script.")
-
-
-def print_config():
-    """
-    List configuration parameter configured backup tool.
-    """
-    config = fetch_backup_config()
-    bold_start = "\033[1m"
-    bold_end = "\033[0m"
-    max_key_length = max(len(key) for key in config.keys())
-    max_value_length = max(len(value) for value in config.values())
-    line_length = max_key_length + max_value_length + 4  # Including spaces around colon
-
-    # Print the top border
-    print(bold_start + "#" * (line_length + 4) + bold_end)  # Adjusting for padding
-
-    for key, value in config.items():
-        # Right-align the key, align colons vertically, and ensure values are left-aligned
-        if key == "REPLICA_PASSWORD":
-            val = "******"
-            print(bold_start + f"# {key.rjust(max_key_length)}" + bold_end + f": {val.ljust(max_value_length)}")
-        else:
-          print(bold_start + f"# {key.rjust(max_key_length)}" + bold_end + f": {value.ljust(max_value_length)}")
-
-    # Print the bottom border
-    print(bold_start + "#" * (line_length + 4) + bold_end)  # Adjusting for padding
-
-def run_external_command(*args):
-    """
-    Run pgbackrest with the given arguments.
-
-    Example:  ./pgedge backrest command info
-    """
-    command = ["pgbackrest"] + list(args)
-    utilx.run_command(command)
-
-def create_stanza():
-    """
-    Create the required stanza data.
-    """
+    """List all available backups using pgBackRest."""
     config = fetch_backup_config()
     try:
-        command = [
-            "pgbackrest",
-            "--stanza=" + util.get_value("BACKUP", "STANZA"),
-            "--pg1-path=" + util.get_value("BACKUP", "PG_PATH"),
-            #"--pg1-host=" + util.get_value("BACKUP", "PRIMARY_HOST"),
-            "--pg1-port=" + util.get_value("BACKUP", "PRIMARY_PORT"),
-            "--pg1-user=" + util.get_value("BACKUP", "PRIMARY_USER"),
-            "--pg1-socket-path=" + util.get_value("BACKUP", "PG_SOCKET_PATH"),
-            "--repo1-cipher-type=" + util.get_value("BACKUP", "REPO_CIPHER_TYPE"),
-            "--repo1-path=" + util.get_value("BACKUP", "REPO_PATH"),
-            "--log-level-console=info",
-            "--log-level-file=info",
-            "stanza-create"
-        ]
-        # Adding repository type specific configurations
-        if config["REPO1_TYPE"] == "s3":
-            command.extend([
-                "--repo1-type", "s3",
-                "--repo1-s3-bucket", config["S3_BUCKET"],
-                "--repo1-s3-region", config["S3_REGION"],
-                "--repo1-s3-endpoint", config["S3_ENDPOINT"],
-            ])
-        elif config["REPO1_TYPE"] == "posix":
-            command.extend(["--repo1-path", config["REPO_PATH"]])
-        subprocess.run(command, check=True)
-        util.message("Stanza created successfully.")
+        command = ["pgbackrest", "info", "--output=json"]
+        command_output = subprocess.check_output(
+            command,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True
+        )
+        backups_info = json.loads(command_output)
+
+        backup_table = []
+        for stanza_info in backups_info:
+            for backup in stanza_info.get('backup', []):
+                backup_details = [
+                    stanza_info['name'],
+                    backup.get('label', 'N/A'),
+                    datetime.utcfromtimestamp(backup['timestamp']['start']).strftime('%Y-%m-%d %H:%M:%S'),
+                    datetime.utcfromtimestamp(backup['timestamp']['stop']).strftime('%Y-%m-%d %H:%M:%S'),
+                    backup.get('type', 'N/A'),
+                    f"{backup.get('info', {}).get('size', 0) / (1024**3):.2f} GB"
+                ]
+                backup_table.append(backup_details)
+
+        headers = ["Stanza Name", "Label", "Start Time", "End Time", "Type", "Size (GB)"]
+        print(tabulate(backup_table, headers=headers, tablefmt="grid"))
+
     except subprocess.CalledProcessError as e:
-        util.message(f"Error creating stanza: {e}")
+        util.message(f"Error executing pgBackRest info command: {e.output}")
+
+def modify_hba_conf():
+  new_rules = [
+      {
+          "type": "host",
+          "database": "replication",
+          "user": "all",
+          "address": "127.0.0.1/0",
+          "method": "trust"
+      }
+  ]
+  util.update_pg_hba_conf(pgV(), new_rules)
+
+def modify_postgresql_conf(stanza):
+    """
+    Modify 'postgresql.conf' to integrate with pgbackrest.
+    """
+    aCmd = f"pgbackrest --stanza={stanza} archive-push %p"
+    util.change_pgconf_keyval(pgV(), "archive_command", aCmd, p_replace=True)
+    util.change_pgconf_keyval(pgV(), "archive_mode", "on", p_replace=True)
+
+def run_external_command(*args):
+    """Execute an external pgBackRest command."""
+
+    command = args
+    result = utilx.run_command(command)
+    if result["success"]:
+        util.message("Command executed successfully.")
+    else:
+        utilx.ereport('Error', 'Command execution failed', detail=result["error"])
+
+def validate_stanza_config(stanza_name, config):
+    """
+    Validate that all required parameters for a stanza are set.
+    """
+    required_params = ["pg1-path", "pg1-user", "pg1-database", "db-socket-path", "pg1-port", "pg1-host"]
+    missing_params = [param for param in required_params if not config["stanza"].get(stanza_name, {}).get(param)]
+    if missing_params:
+        raise ValueError(f"Missing configuration parameters for stanza {stanza_name}: {', '.join(missing_params)}")
+    return True
+
+def create_stanza(stanza, verbose=True):
+    """
+    Create the required stanza for pgBackRest and configure PostgreSQL settings after ensuring all values are properly set.
+    """
+    # Fetch the current configuration
+    config = fetch_backup_config()
+
+    if validate_stanza_config(stanza, config):
+        command = ["pgbackrest", "--stanza", stanza, "stanza-create"]
+        result = utilx.run_command(command, capture_output = not verbose)
+        if result["success"] == False:
+            utilx.echo_message('Error', f'Failed to create or configure stanza', level = "error")
+        modify_postgresql_conf(stanza)
+        modify_hba_conf()
+        command = ["./pgedge", "restart", pgV()]
+        result = utilx.run_command(command, capture_output = not verbose)
+        if result["success"] == False:
+            utilx.echo_message(f"Error: failed to restart postgresql cluster", level = "error")
 
 if __name__ == "__main__":
     fire.Fire({
@@ -371,7 +358,8 @@ if __name__ == "__main__":
         "create-stanza": create_stanza,
         "create-replica": create_replica,
         "list-backups": list_backups,
-        "config": print_config,
+        "show-config": show_config,
+        "save-config": save_config,
         "command": run_external_command,
     })
 

--- a/src/backrest/install-backrest.py
+++ b/src/backrest/install-backrest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 #     Copyright (c)  2022-2024 PGEDGE  #
+
 import os
 import subprocess
 import time
@@ -8,75 +9,120 @@ import getpass
 from crontab import CronTab
 import subprocess
 import util
+import utilx
 
 thisDir = os.path.dirname(os.path.realpath(__file__))
 osUsr = util.get_user()
 usrUsr = osUsr + ":" + osUsr
 
+os.chdir(f"{thisDir}")
+
 def exit_rm_backrest(msg):
     util.message(f"{msg}", "error")
-    osSys("./pgedge remove backrest")
+    osSys(f"{thisDir}/pgedge remove backrest")
     sys.exit(1)
 
-pgV = ""
-if os.path.isdir("pg14"):
-    pgV = "pg14"
-elif os.path.isdir("pg15"):
-    pgV = "pg15"
-elif os.path.isdir("pg16"):
-    pgV = "pg16"
-if pgV == "":
+
+def pgV():
+    pg_versions = ["pg14", "pg15", "pg16"]
+    os.chdir(f"{thisDir}/../")
+    for pg_version in pg_versions:
+        if os.path.isdir(pg_version):
+            return pg_version
+
     exit_rm_backrest("pg14, 15 or 16 must be installed")
 
-os.chdir(thisDir)
-
-def osSys(p_input, p_display=True):
+def osSys(p_input, p_display=False):
     if p_display:
         util.message("# " + p_input)
     rc = os.system(p_input)
     return rc
 
-def configure_backup_settings(stanza_name):
-    """
-    Configures backup settings based on environment variables and system properties.
-    """
-    pg_data_path = os.getenv('PSX', '/usr/local/pgsql') + "/data/" + stanza_name
-    pg_restore_path = os.getenv('PSX', '/usr/local/pgsql') + "/restore/" + stanza_name
-
-    current_user = getpass.getuser()
-
-    # Backup configuration settings
-    backup_config = {
-        "BACKUP_PATH": "/path/to/backup",
-        "DATABASE": "postgres",
-        "PG_PATH": pg_data_path,
-        "PG_USER": current_user,
-        "PG_SOCKET_PATH": "/tmp",
-        "REPO_CIPHER_TYPE": "aes-256-cbc",
-        "REPO_CIPHER_PASSWORD": "",
-        "REPO_PATH": "/var/lib/pgbackrest",
-        "REPO_RETENTION_FULL_TYPE": "time",
-        "REPO_RETENTION_FULL": "31",
-        "BACKUP_TOOL": "pgbackrest",
-        "STANZA": stanza_name,
-        "PRIMARY_HOST": "127.0.0.1",
-        "PRIMARY_PORT": "5432",
-        "PRIMARY_USER": current_user,
-        "REPLICA_PASSWORD": "123",
-        "RECOVERY_TARGET_TIME": "",
-        "RESTORE_PATH": pg_restore_path,
-        "PROCESS_MAX": "3",
-        "REPO1_TYPE": "local",
-        "BACKUP_TYPE": "full",
-        "S3_BUCKET": "bucket-name",
-        "S3_REGION": "eu-west-2",
-        "S3_ENDPOINT": "s3.amazonaws.com"
+def configure_backup_settings():
+    stanza = "pg16"
+    repo1_path = f"/var/lib/pgbackrest/"
+    config = {
+        "main": {
+            "restore_path": "xx",
+            "backup-type" : "full",
+            "stanza_count" : "1"
+        },
+        "global": {
+            "repo1-path": repo1_path,
+            "repo1-host-user": "xx",
+            "repo1-host": "xx",
+            "repo1-type": "posix",
+            "repo1-cipher-pass": "xx",
+            "repo1-cipher-type": "aes-256-cbc",
+            "repo1-s3-bucket": "xx",
+            "repo1-s3-region": "eu-west-2",
+            "repo1-s3-key": "xx",
+            "repo1-s3-key-secret": "xx",
+            "repo1-s3-endpoint": "s3.amazonaws.com",
+            "repo1-retention-full": "7",
+            "repo1-retention-full-type": "count",
+            "process-max" : "3",
+            "log-level-console": "info"
+        },
+        "stanza": {
+            "stanza0" : "xx",
+            "pg1-path0" : "xx",
+            "pg1-user0" : "xx",
+            "pg1-port0" : "5432",
+            "pg1-host0" : "127.0.0.1",
+            "db-socket-path0" : "/tmp",
+            "global:archive-push0": {
+                "compress-level": "3"
+            }
+        }
     }
+    for section, parameters in config.items():
+        if isinstance(parameters, dict):
+            for key, sub_params in parameters.items():
+                if isinstance(sub_params, dict):
+                    for sub_key, value in sub_params.items():
+                        util.set_value(f"BACKUP", sub_key, value)
+                else:
+                    util.set_value("BACKUP", key, sub_params)
 
-    for key, value in backup_config.items():
-        util.set_value("BACKUP", key, value)
+def save_config(filename="pgbackrest.conf"):
+    """Save the current pgbackrest configuration to a file in standard format."""
+    config = fetch_backup_config()
+    lines = []
 
-    print("Backup configuration has been set successfully.")
+    # Write global settings
+    if config["global"]:
+        lines.append("[global]")
+        for key, value in config["global"].items():
+            if key == "compress-level":
+                continue  # Handle this key separately in its own section
+            if value != " ":
+                lines.append(f"{key} = {value}")
+        lines.append("")  # Add a newline for separation
+
+        # Handle global:archive-push specifically if needed
+        if "compress-level" in config["global"]:
+            lines.append("[global:archive-push]")
+            lines.append(f"compress-level = {config['global']['compress-level']}")
+            lines.append("")  # Add a newline for separation
+
+    # Write stanza sections
+    stanza_count = int(config["main"].get("stanza_count", 1))
+    for i in range(stanza_count):
+        stanza_name = util.get_value("BACKUP", f"stanza{i}")
+        if stanza_name in config["stanza"]:
+            lines.append(f"[{stanza_name}]")
+            for key, value in config["stanza"][stanza_name].items():
+                clean_key = key.replace(str(i), '')  # Remove the index from key names
+                if value != " ":
+                    lines.append(f"{clean_key} = {value}")
+            lines.append("")  # Add a newline for separation
+
+    # Write the configuration to file
+    with open(f"{thisDir}/{filename}", "w") as f:
+        f.write("\n".join(lines))
+    osSys(f"sudo cp {thisDir}/{filename} /etc/pgbackrest/")
+    return filename
 
 def setup_pgbackrest_links():
     """
@@ -93,24 +139,37 @@ def setup_pgbackrest_conf():
     Create pgbackrest configuration file and directories.
     """
     config = fetch_backup_config()
-    usrUsr = config["PG_USER"]
-    dataDir = config["PG_PATH"]
+    usrUsr = osUsr
+    parentDir = os.path.dirname(thisDir)
+    
+    dataDir = f"{parentDir}/data/{pgV()}"
+    restoreDir = f"{parentDir}/restore"
 
+    save_config()
     osSys(f"sudo chown {usrUsr} /var/log/pgbackrest")
     osSys("sudo mkdir -p /etc/pgbackrest /etc/pgbackrest/conf.d")
-    osSys("sudo cp pgbackrest.conf /etc/pgbackrest/")
     osSys("sudo chmod 640 /etc/pgbackrest/pgbackrest.conf")
     osSys(f"sudo chown {usrUsr} /etc/pgbackrest/pgbackrest.conf")
 
     osSys("sudo mkdir -p /var/lib/pgbackrest")
     osSys("sudo chmod 750 /var/lib/pgbackrest")
-    osSys(f"sudo chown {usrUsr} /var/lib/pgbackrest")
+    osSys(f"sudo chown -R {usrUsr}:{usrUsr} /var/lib/pgbackrest")
+
     conf_file = thisDir + "/pgbackrest.conf"
-    util.replace("pgXX", pgV, conf_file, True)
+    util.replace("pgXX", pgV(), conf_file, True)
     util.replace("pg1-path=xx", "pg1-path=" + dataDir, conf_file, True)
     util.replace("pg1-user=xx", "pg1-user=" + usrUsr, conf_file, True)
     util.replace("pg1-database=xx", "pg1-database=" + "postgres", conf_file, True)
-    osSys("cp " + conf_file + "  /etc/pgbackrest/.")
+    
+    util.set_value("BACKUP", "restore_path", restoreDir)
+    
+    util.set_value("BACKUP", "repo1-host", " ")
+    util.set_value("BACKUP", "repo1-host-user", usrUsr)
+    
+    util.set_value("BACKUP", "stanza0", pgV())
+    util.set_value("BACKUP", "pg1-path0", dataDir)
+    util.set_value("BACKUP", "pg1-user0", usrUsr)
+    util.set_value("BACKUP", "pg1-database0", "postgres")
 
 def generate_cipher_pass():
     """
@@ -121,49 +180,19 @@ def generate_cipher_pass():
     bCipher = subprocess.check_output(cmd, shell=True)
     sCipher = bCipher.decode("ascii")
     util.replace("repo1-cipher-pass=xx", f"repo1-cipher-pass={sCipher}", conf_file, True)
-    util.set_value("BACKUP", "REPO_CIPHER_PASSWORD", sCipher)
+    util.set_value("BACKUP", "repo1-cipher-pass", sCipher)
 
 def modify_hba_conf():
   new_rules = [
       {
-          "type": "host",
-          "database": "replication",
-           "user": "all",
-           "address": "127.0.0.1/0",
-           "method": "trust"
+            "type": "host",
+            "database": "replication",
+            "user": "all",
+            "address": "127.0.0.1/0",
+            "method": "trust"
       }
   ]
-  util.update_pg_hba_conf(pgV, new_rules)
-
-def modify_postgresql_conf(stanza):
-    """
-    Modify 'postgresql.conf' to integrate with pgBackRest.
-    """
-    aCmd = f"pgbackrest --stanza={stanza} archive-push %p"
-    util.change_pgconf_keyval(stanza, "archive_command", aCmd, p_replace=True)
-    util.change_pgconf_keyval(stanza, "archive_mode", "on", p_replace=True)
-
-def create_stanza():
-    try:
-        command = [
-            "pgbackrest",
-            "--stanza=" + util.get_value("BACKUP", "STANZA"),
-            "--pg1-path=" + util.get_value("BACKUP", "PG_PATH"),
-            #"--pg1-host=" + util.get_value("BACKUP", "PRIMARY_HOST"),
-            "--pg1-port=" + util.get_value("BACKUP", "PRIMARY_PORT"),
-            "--pg1-user=" + util.get_value("BACKUP", "PRIMARY_USER"),
-            "--pg1-socket-path=" + util.get_value("BACKUP", "PG_SOCKET_PATH"),
-            "--repo1-cipher-type=" + util.get_value("BACKUP", "REPO_CIPHER_TYPE"),
-            "--repo1-path=" + util.get_value("BACKUP", "REPO_PATH"),
-            "--log-level-console=info",
-            "--log-level-file=info",
-            "stanza-create"
-        ]
-        subprocess.run(command, check=True)
-        print("Stanza created successfully.")
-    except subprocess.CalledProcessError as e:
-        print("Error creating stanza:", e)
-
+  util.update_pg_hba_conf(pgV(), new_rules)
 
 def create_or_update_job(crontab_lines, job_comment, detailed_comment, new_job):
     job_identifier = f"# {job_comment}"
@@ -183,7 +212,7 @@ def create_or_update_job(crontab_lines, job_comment, detailed_comment, new_job):
         crontab_lines.extend([job_identifier + "\n", detailed_comment_line, new_job])
 
 def define_cron_job():
-    stanza = util.get_value("BACKUP", "STANZA")
+    stanza = util.get_value("BACKUP", "stanza")
     full_backup_command = f"pgbackrest --stanza={stanza} --type=full backup"
     incr_backup_command = f"pgbackrest --stanza={stanza} --type=incr backup"
     expire_backup_command = f"pgbackrest --stanza={stanza} expire"
@@ -216,61 +245,40 @@ def define_cron_job():
     osSys(f"sudo cat {backrest_crontab_path} | sudo tee {system_crontab_path} > /dev/null", False)
 
 def fetch_backup_config():
-    """Fetch backup configuration from util module or other configuration source."""
+    """Fetch and return the pgBackRest configuration from system settings."""
     config = {
-        "BACKUP_TOOL": util.get_value("BACKUP", "BACKUP_TOOL"),
-        "STANZA": util.get_value("BACKUP", "STANZA"),
-        "DATABASE": util.get_value("BACKUP", "DATABASE"),
-        "PG_PATH": util.get_value("BACKUP", "PG_PATH"),
-        "PG_SOCKET_PATH": util.get_value("BACKUP", "PG_SOCKET_PATH"),
-        "PG_USER": util.get_value("BACKUP", "PG_USER"),
-        "REPO_CIPHER_TYPE": util.get_value("BACKUP", "REPO_CIPHER_TYPE"),
-        "REPO_PATH": util.get_value("BACKUP", "REPO_PATH"),
-        "REPO_RETENTION_FULL_TYPE": util.get_value("BACKUP", "REPO_RETENTION_FULL_TYPE"),
-        "REPO_RETENTION_FULL": util.get_value("BACKUP", "REPO_RETENTION_FULL"),
-        "PRIMARY_HOST": util.get_value("BACKUP", "PRIMARY_HOST"),
-        "PRIMARY_PORT": util.get_value("BACKUP", "PRIMARY_PORT"),
-        "PRIMARY_USER": util.get_value("BACKUP", "PRIMARY_USER"),
-        "REPLICA_PASSWORD": util.get_value("BACKUP", "REPLICA_PASSWORD"),
-        "RECOVERY_TARGET_TIME": util.get_value("BACKUP", "RECOVERY_TARGET_TIME"),
-        "RESTORE_PATH": util.get_value("BACKUP", "RESTORE_PATH"),
-
-        "REPO1_TYPE": util.get_value("BACKUP", "REPO1_TYPE"),
-
-        "REPO_PATH": util.get_value("BACKUP", "REPO_PATH"),
-        "PG_PATH": util.get_value("BACKUP", "PG_PATH"),
-        "BACKUP_TYPE": util.get_value("BACKUP", "BACKUP_TYPE"),
-
-        "S3_BUCKET": util.get_value("BACKUP", "S3_BUCKET"),
-        "S3_REGION": util.get_value("BACKUP", "S3_REGION"),
-        "S3_ENDPOINT": util.get_value("BACKUP", "S3_ENDPOINT"),
+        "main": {},
+        "global": {},
+        "stanza": {}
     }
+
+    main_params = ["restore_path", "backup-type", "stanza_count"]
+    global_params = [
+        "repo1-retention-full", "repo1-retention-full-type", "repo1-path", "repo1-host-user", "repo1-host",
+        "repo1-cipher-type", "repo1-cipher-pass", "repo1-s3-bucket", "repo1-s3-key-secret", "repo1-s3-key",
+        "repo1-s3-region", "repo1-s3-endpoint", "log-level-console", "repo1-type",
+        "process-max", "compress-level"
+    ]
+    stanza_params = [
+        "pg1-path", "pg1-user", "pg1-database", "db-socket-path", "pg1-port", "pg1-host"
+    ]
+
+    # Fetch main and global parameters
+    for param in main_params:
+        config["main"][param] = util.get_value("BACKUP", param)
+    for param in global_params:
+        config["global"][param] = util.get_value("BACKUP", param)
+
+    # Determine the number of stanzas and fetch their specific parameters
+    stanza_count = int(config["main"].get("stanza_count", 1))
+    for i in range(stanza_count):
+        stanza_name = util.get_value("BACKUP", f"stanza{i}")
+        config["stanza"][stanza_name] = {}
+        for param in stanza_params:
+            indexed_param = f"{param}{i}"
+            config["stanza"][stanza_name][param] = util.get_value("BACKUP", indexed_param)
+
     return config
-
-def print_config():
-    """
-    List configuration parameter configured backup tool.
-    """
-    config = fetch_backup_config()
-    bold_start = "\033[1m"
-    bold_end = "\033[0m"
-    max_key_length = max(len(key) for key in config.keys())
-    max_value_length = max(len(value) for value in config.values())
-    line_length = max_key_length + max_value_length + 4  # Including spaces around colon
-
-    # Print the top border
-    print(bold_start + "#" * (line_length + 4) + bold_end)  # Adjusting for padding
-
-    for key, value in config.items():
-        # Right-align the key, align colons vertically, and ensure values are left-aligned
-        if key == "REPLICA_PASSWORD":
-            val = "******"
-            print(bold_start + f"# {key.rjust(max_key_length)}" + bold_end + f": {val.ljust(max_value_length)}")
-        else:
-          print(bold_start + f"# {key.rjust(max_key_length)}" + bold_end + f": {value.ljust(max_value_length)}")
-
-    # Print the bottom border
-    print(bold_start + "#" * (line_length + 4) + bold_end)  # Adjusting for padding
 
 def print_header(header):
     bold_start = "\033[1m"
@@ -278,34 +286,17 @@ def print_header(header):
     print(bold_start + "##### " + header + " #####"+ bold_end)
 
 def main():
-    if os.path.isdir("/var/lib/pgbackrest"):
-        exit_rm_backrest("ERROR: '/var/lib/pgbackrest' directory already exists")
-
+    stanza = pgV()
+    if os.path.isdir(f"/var/lib/pgbackrest/{stanza}/"):
+        utilx.ereport("WARNING", "/var/lib/pgbackrest directory already exists")
+    
     print_header("Configuring pgbackrest")
-    configure_backup_settings(pgV)
+    configure_backup_settings()
     generate_cipher_pass()
     setup_pgbackrest_links()
     setup_pgbackrest_conf()
     usrUsr = f"{util.get_user()}:{util.get_user()}"
-    osSys("rm -r lib", False)
-    osSys("rm -r share", False)
-    print_config()
-
-    print_header("Configuring pgbackrest's setting in postgresql.conf")
-    modify_postgresql_conf(pgV)
-    modify_hba_conf()
-
-    print_header("Restarting PostgreSQL instance " + pgV)
-    osSys(f"../pgedge restart {pgV}")
-    time.sleep(3)
-
-    print_header("Creating stanza for pgbackrest" + pgV)
-    create_stanza()
-
-    print_header("Configuraing cron jobs for pgbackrest")
-    define_cron_job()
-
-    print("pgbackrest installed successfully")
+    osSys("pgbackrest version")
 
 if __name__ == "__main__":
     main()

--- a/src/backrest/pgbackrest.conf
+++ b/src/backrest/pgbackrest.conf
@@ -1,25 +1,26 @@
-[pgXX]
-pg1-path=xx
-pg1-user=xx
-pg1-database=xx
-db-socket-path=/tmp
-
 [global]
-repo1-cipher-pass=xx
-repo1-cipher-type=aes-256-cbc
-repo1-path=/var/lib/pgbackrest
-repo1-retention-full=7
-repo1-retention-full-type=count
-
-repo1-s3-bucket=bucket-name
-repo1-s3-region=eu-west-2
-repo1-s3-key=xx
-repo1-s3-key-secret=xx
-repo1-s3-endpoint=s3.amazonaws.com
-
-
-log-level-console=info
-
+repo1-retention-full = 7
+repo1-retention-full-type = count
+repo1-path = /var/lib/pgbackrest/
+repo1-host-user = xx
+repo1-host = xx
+repo1-cipher-type = aes-256-cbc
+repo1-cipher-pass = xx
+repo1-s3-bucket = xx
+repo1-s3-key-secret = xx
+repo1-s3-key = xx
+repo1-s3-region = eu-west-2
+repo1-s3-endpoint = s3.amazonaws.com
+log-level-console = info
+repo1-type = posix
+process-max = 3
 
 [global:archive-push]
-compress-level=3
+compress-level = 3
+
+[xx]
+pg1-path = xx
+pg1-user = xx
+pg1-database = 
+db-socket-path = /tmp
+pg1-port = 5432


### PR DESCRIPTION
Implemented a new feature to expand existing clusters by adding new nodes.

This update introduces the command:

    ./pgedge cluster add-node <cluster_name> <source_node> <target_node>

Example Usage:
- `<cluster_name>`: Specifies the name of the cluster to modify (e.g., 'demo').
- `<source_node>`: Specifies the existing node in the cluster from which settings/data are copied (e.g., 'n1').
- `<target_node>`: Specifies the new node to be added to the cluster (e.g., 'n3').