### PR TITLE
Updated config.env to include EDGE_SLEEP

### DIFF
--- a/test/t/8064_env_delete_replication_check.pl
+++ b/test/t/8064_env_delete_replication_check.pl
@@ -29,6 +29,9 @@ my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
 my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
 #add 1 to the default port for use with node n2
 my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
+my $seconds = $ENV{'EDGE_SLEEP'};
+
+
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
 print("The home directory is $homedir1\n"); 
@@ -127,9 +130,10 @@ if(!(contains(@$stdout_buf8[0], "888")))
    # Listing table contents of Port2 6433
    
    #   print("Adding call to sleep function")
-   my($success999, $error_message999, $full_buf999, $stdout_buf999, $stderr_buf999)= IPC::Cmd::run(command => sleep(12), verbose => 0);
-   print("stdout_buf999= @$stdout_buf999\n");
-
+   my $cmd999 = qq(sleep($seconds));
+   my($success999, $error_message999, $full_buf999, $stdout_buf999, $stderr_buf999)= IPC::Cmd::run(command => $cmd999, verbose => 0);
+   print("cmd999 = $cmd999\n");
+   
    print("INSERT FUNCTION REPLICATION CHECK IN NODE n2 \n");
    print ("-"x45,"\n");
    my $cmd11 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo");

--- a/test/t/8069_env_insert_replication_check.pl
+++ b/test/t/8069_env_insert_replication_check.pl
@@ -28,6 +28,8 @@ print("whoami = $ENV{EDGE_REPUSER}\n");
 my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
 my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
 my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
+my $seconds = $ENV{'EDGE_SLEEP'};
+
 
 print("The home directory is $homedir1\n"); 
 
@@ -221,6 +223,11 @@ if(!(contains(@$stdout_buf16[0], "0 rows")))
 }
 
   # Listing table contents of Port2 6433
+  #
+  # print("Adding call to sleep function")
+  my $cmd999 = qq(sleep($seconds));
+  my($success999, $error_message999, $full_buf999, $stdout_buf999, $stderr_buf999)= IPC::Cmd::run(command => $cmd999, verbose => 0);
+  
    print("TRUNCATE FUNCTION REPLICATION CHECK IN NODE n2\n");
     print ("-"x45,"\n");
   my $cmd17 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo");

--- a/test/t/8074_env_update_replication_check.pl
+++ b/test/t/8074_env_update_replication_check.pl
@@ -27,6 +27,10 @@ no warnings 'uninitialized';
 my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
 my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
 my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
+my $seconds = $ENV{'EDGE_SLEEP'};
+
+
+
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
 print("The home directory is $homedir1\n"); 
@@ -127,10 +131,9 @@ if(!(contains(@$stdout_buf9[0], "888")))
  
    print("INSERT=TRUE REPLICATION CHECK IN NODE n2\n");
    
-   #   print("Adding call to sleep function")
-   my($success999, $error_message999, $full_buf999, $stdout_buf999, $stderr_buf999)= IPC::Cmd::run(command => sleep(7), verbose => 0);
-   print("stdout_buf999= @$stdout_buf999\n");
-
+  # print("Adding call to sleep function")
+  my $cmd999 = qq(sleep($seconds));
+  my($success999, $error_message999, $full_buf999, $stdout_buf999, $stderr_buf999)= IPC::Cmd::run(command => $cmd999, verbose => 0);
 
    print ("-"x45,"\n");
    my $cmd10 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo WHERE col1=888");

--- a/test/t/8079_env_truncate_replication_check.pl
+++ b/test/t/8079_env_truncate_replication_check.pl
@@ -26,6 +26,9 @@ no warnings 'uninitialized';
 my $homedir1="$ENV{EDGE_CLUSTER_DIR}/n1/pgedge";
 my $homedir2="$ENV{EDGE_CLUSTER_DIR}/n2/pgedge";
 my $myport2 = $ENV{'EDGE_START_PORT'} + 1;
+my $seconds = $ENV{'EDGE_SLEEP'};
+
+
 
 print("whoami = $ENV{EDGE_REPUSER}\n");
 
@@ -169,9 +172,9 @@ if(!(contains(@$stdout_buf9[0], "888")))
  
    print("INSERT=TRUE REPLICATION CHECK IN NODE n2\n");
    
-   #   print("Adding call to sleep function")
-   my($success999, $error_message999, $full_buf999, $stdout_buf999, $stderr_buf999)= IPC::Cmd::run(command => sleep(17), verbose => 0);
-   print("stdout_buf999= @$stdout_buf999\n");
+  # print("Adding call to sleep function")
+  my $cmd999 = qq(sleep($seconds));
+  my($success999, $error_message999, $full_buf999, $stdout_buf999, $stderr_buf999)= IPC::Cmd::run(command => $cmd999, verbose => 0);
 
    print ("-"x45,"\n");
    my $cmd10 = qq($homedir2/$ENV{EDGE_COMPONENT}/bin/psql  -h $ENV{EDGE_HOST} -p $myport2 -d $ENV{EDGE_DB} -c "SELECT * FROM foo WHERE col1=888");

--- a/test/t/lib/config.env
+++ b/test/t/lib/config.env
@@ -3,6 +3,10 @@ export EDGE_INSTALL_SCRIPT=install.py
 export EDGE_REPO=https://pgedge-upstream.s3.amazonaws.com/REPO/$EDGE_INSTALL_SCRIPT
 export EDGE_HOST=127.0.0.1
 
+# Use this environment variable to set the number of seconds that a timing-sensitive test
+# sleeps before confirming a result has been replicated.
+export EDGE_SLEEP=5
+
 # Your setup scripts should start at the following port, and iterate through the setup for the number of nodes in 
 # EDGE_NODES.
 

--- a/test/t/spock_sub_create_synch_all_n2.py
+++ b/test/t/spock_sub_create_synch_all_n2.py
@@ -14,6 +14,7 @@ pw=os.getenv("EDGE_PASSWORD","password")
 host=os.getenv("EDGE_HOST","localhost")
 repuser=os.getenv("EDGE_REPUSER","repuser")
 dbname=os.getenv("EDGE_DB","lcdb")
+seconds=int(os.getenv("EDGE_SLEEP"))
 
 n2_port = port + 1
 
@@ -42,7 +43,7 @@ print(f"The spock sub-create command for sub_n2n1 returned: {sub_create.stdout}"
 print("*"*100)
 
 # print("Napping")
-time.sleep(3)
+time.sleep(seconds)
 
 # Check for public.foo in pg_tables:
 table_check = util_test.read_psql("SELECT * FROM pg_tables WHERE schemaname='public';",host,dbname,n2_port,pw,usr)

--- a/test/t/spock_sub_create_synch_data_n2.py
+++ b/test/t/spock_sub_create_synch_data_n2.py
@@ -14,6 +14,7 @@ pw=os.getenv("EDGE_PASSWORD","password")
 host=os.getenv("EDGE_HOST","localhost")
 repuser=os.getenv("EDGE_REPUSER","repuser")
 dbname=os.getenv("EDGE_DB","lcdb")
+seconds=int(os.getenv("EDGE_SLEEP"))
 
 n2_port = port + 1
 
@@ -47,7 +48,7 @@ print(f"The spock sub-create command for sub_n2n1 returned: {sub_create.stdout}"
 print("*"*100)
 
 # Napping
-time.sleep(3)
+time.sleep(seconds)
 
 # Check for a user that was added to n1 in n2's public.foo:
 read_foo = util_test.read_psql("SELECT * FROM public.foo;",host,dbname,n2_port,pw,usr)

--- a/test/t/spock_sub_create_synch_struct_n2.py
+++ b/test/t/spock_sub_create_synch_struct_n2.py
@@ -14,6 +14,7 @@ pw=os.getenv("EDGE_PASSWORD","password")
 host=os.getenv("EDGE_HOST","localhost")
 repuser=os.getenv("EDGE_REPUSER","repuser")
 dbname=os.getenv("EDGE_DB","lcdb")
+seconds=int(os.getenv("EDGE_SLEEP"))
 
 n2_port = port + 1
 
@@ -42,7 +43,7 @@ print(f"The spock sub-create command for sub_n2n1 returned: {sub_create.stdout}"
 print("*"*100)
 
 # Napping
-time.sleep(3)
+time.sleep(seconds)
 
 # Check for public.foo in pg_tables:
 rep_check = util_test.read_psql("SELECT * FROM pg_tables WHERE schemaname = 'public';",host,dbname,n2_port,pw,usr)


### PR DESCRIPTION
The value of EDGE_SLEEP (in seconds) is passed to the sleep functions in tests that test replication to n2, but that need a little more time than the test takes.