### PR TITLE
autoDDL tests around CREATE TABLE

### DIFF
--- a/test/schedule_files/auto_ddl_schedule
+++ b/test/schedule_files/auto_ddl_schedule
@@ -24,7 +24,12 @@ t/6011_setup_autoddl_gucs_on_n2.pl
 ##
 # autoDDL scripts
 ##
-
+t/auto_ddl/6100a_table_datatypes_create_alter_n1.sql
+t/auto_ddl/6100b_table_validate_and_drop_n2.sql
+t/auto_ddl/6100c_table_validate_n1.sql
+t/auto_ddl/6111a_table_tx_ctas_selectinto_like.sql
+t/auto_ddl/6111b_table_validate_and_drop_n2.sql
+t/auto_ddl/6111c_table_validate_n1.sql
 ##
 # cleanup scripts
 ##

--- a/test/t/auto_ddl/6100a_table_datatypes_create_alter_n1.out
+++ b/test/t/auto_ddl/6100a_table_datatypes_create_alter_n1.out
@@ -1,0 +1,867 @@
+-- 6100a_create_alter_table_n1.sql
+-- This script creates and alters tables on node n1 to test the autoDDL functionality.
+-- It includes a wide variety of data types and exercises several CREATE TABLE/ ALTER TABLE DDL constructs.
+-- Also regularly verifying spock.tables 
+-- Prepared statement for spock.tables so that we can execute it frequently in the script below
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname = $1 ORDER BY relid;
+PREPARE
+-- Create a table for employee details with various data types
+CREATE TABLE employees (
+    emp_id INT PRIMARY KEY,
+    first_name VARCHAR(50) NOT NULL,
+    last_name VARCHAR(50) NOT NULL,
+    email VARCHAR(100) UNIQUE NOT NULL,
+    hire_date DATE,
+    birth_time TIME WITHOUT TIME ZONE,
+    salary NUMERIC(10, 2),
+    full_time BOOLEAN DEFAULT TRUE,
+    street_address TEXT,
+    metadata JSON,
+    start_timestamp TIMESTAMP WITHOUT TIME ZONE,
+    emp_coordinates POINT,
+    CONSTRAINT chk_salary CHECK (salary > 0)
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into employees table
+INSERT INTO employees (emp_id, first_name, last_name, email, hire_date, birth_time, salary, full_time, street_address, metadata, start_timestamp, emp_coordinates) VALUES
+(1, 'John', 'Doe', 'john.doe@example.com', '2023-01-15', '08:30:00', 60000, TRUE, '123 Main St', '{"department": "HR"}', '2023-01-15 08:30:00', '(10, 20)'),
+(2, 'Jane', 'Smith', 'jane.smith@example.com', '2023-03-22', '09:00:00', 65000, FALSE, '456 Elm St', '{"department": "Engineering"}', '2023-03-22 09:00:00', '(30, 40)');
+INSERT 0 2
+-- Validate the structure, spock.tables catalog table and data
+\d employees
+                            Table "public.employees"
+     Column      |            Type             | Collation | Nullable | Default 
+-----------------+-----------------------------+-----------+----------+---------
+ emp_id          | integer                     |           | not null | 
+ first_name      | character varying(50)       |           | not null | 
+ last_name       | character varying(50)       |           | not null | 
+ email           | character varying(100)      |           | not null | 
+ hire_date       | date                        |           |          | 
+ birth_time      | time without time zone      |           |          | 
+ salary          | numeric(10,2)               |           |          | 
+ full_time       | boolean                     |           |          | true
+ street_address  | text                        |           |          | 
+ metadata        | json                        |           |          | 
+ start_timestamp | timestamp without time zone |           |          | 
+ emp_coordinates | point                       |           |          | 
+Indexes:
+    "employees_pkey" PRIMARY KEY, btree (emp_id)
+    "employees_email_key" UNIQUE CONSTRAINT, btree (email)
+Check constraints:
+    "chk_salary" CHECK (salary > 0::numeric)
+
+EXECUTE spocktab('employees');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | employees | default
+(1 row)
+
+-- Create a table for department details
+CREATE TABLE departments (
+    dept_id INT PRIMARY KEY,
+    dept_name VARCHAR(100) NOT NULL,
+    location VARCHAR(100),
+    established DATE,
+    budget MONEY,
+    active BOOLEAN
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into departments table
+INSERT INTO departments (dept_id, dept_name, location, established, budget, active) VALUES
+(1, 'Human Resources', 'New York', '2010-01-01', '$1000000', TRUE),
+(2, 'Engineering', 'San Francisco', '2015-06-15', '$2000000', TRUE);
+INSERT 0 2
+-- Validate the structure, spock.tables catalog table and data
+\d departments
+                      Table "public.departments"
+   Column    |          Type          | Collation | Nullable | Default 
+-------------+------------------------+-----------+----------+---------
+ dept_id     | integer                |           | not null | 
+ dept_name   | character varying(100) |           | not null | 
+ location    | character varying(100) |           |          | 
+ established | date                   |           |          | 
+ budget      | money                  |           |          | 
+ active      | boolean                |           |          | 
+Indexes:
+    "departments_pkey" PRIMARY KEY, btree (dept_id)
+
+EXECUTE spocktab('departments');
+ nspname |   relname   | set_name 
+---------+-------------+----------
+ public  | departments | default
+(1 row)
+
+-- Alter table employees to add new columns, modify existing columns, and add constraints
+ALTER TABLE employees ADD COLUMN middle_name VARCHAR(100);
+INFO:  DDL statement replicated.
+ALTER TABLE
+ALTER TABLE employees ADD COLUMN dept_id INT;
+INFO:  DDL statement replicated.
+ALTER TABLE
+ALTER TABLE employees ADD CONSTRAINT fk_dept FOREIGN KEY (dept_id) REFERENCES departments (dept_id);
+INFO:  DDL statement replicated.
+ALTER TABLE
+ALTER TABLE employees ALTER COLUMN salary SET NOT NULL;
+INFO:  DDL statement replicated.
+ALTER TABLE
+ALTER TABLE employees RENAME COLUMN street_address TO address;
+INFO:  DDL statement replicated.
+ALTER TABLE
+-- Validate the structure, spock.tables catalog table and data
+\d employees
+                            Table "public.employees"
+     Column      |            Type             | Collation | Nullable | Default 
+-----------------+-----------------------------+-----------+----------+---------
+ emp_id          | integer                     |           | not null | 
+ first_name      | character varying(50)       |           | not null | 
+ last_name       | character varying(50)       |           | not null | 
+ email           | character varying(100)      |           | not null | 
+ hire_date       | date                        |           |          | 
+ birth_time      | time without time zone      |           |          | 
+ salary          | numeric(10,2)               |           | not null | 
+ full_time       | boolean                     |           |          | true
+ address         | text                        |           |          | 
+ metadata        | json                        |           |          | 
+ start_timestamp | timestamp without time zone |           |          | 
+ emp_coordinates | point                       |           |          | 
+ middle_name     | character varying(100)      |           |          | 
+ dept_id         | integer                     |           |          | 
+Indexes:
+    "employees_pkey" PRIMARY KEY, btree (emp_id)
+    "employees_email_key" UNIQUE CONSTRAINT, btree (email)
+Check constraints:
+    "chk_salary" CHECK (salary > 0::numeric)
+Foreign-key constraints:
+    "fk_dept" FOREIGN KEY (dept_id) REFERENCES departments(dept_id)
+
+EXECUTE spocktab('employees');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | employees | default
+(1 row)
+
+-- Insert additional data with new columns
+INSERT INTO employees (emp_id, first_name, middle_name, last_name, email, hire_date, birth_time, salary, full_time, address, metadata, start_timestamp, emp_coordinates, dept_id) VALUES
+(3, 'Alice', 'M', 'Brown', 'alice.brown@example.com', '2023-05-10', '07:45:00', 70000, TRUE, '789 Maple St', '{"department": "Engineering"}', '2023-05-10 07:45:00', '(50, 60)', 2),
+(4, 'Bob', 'J', 'Johnson', 'bob.johnson@example.com', '2023-02-20', '10:00:00', 62000, FALSE, '101 Pine St', '{"department": "HR"}', '2023-02-20 10:00:00', '(70, 80)', 1);
+INSERT 0 2
+-- Create more tables to cover various types and constraints
+CREATE TABLE projects (
+    project_id INT PRIMARY KEY,
+    project_name VARCHAR(100) NOT NULL,
+    start_date DATE,
+    end_date DATE,
+    budget NUMERIC(12, 2) CHECK (budget > 0),
+    active BOOLEAN,
+    metadata JSON
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into projects table
+INSERT INTO projects (project_id, project_name, start_date, end_date, budget, active, metadata) VALUES
+(1, 'Project Alpha', '2023-01-01', '2023-06-30', 500000.00, TRUE, '{"client": "Client A"}'),
+(2, 'Project Beta', '2023-02-15', '2023-12-31', 750000.00, TRUE, '{"client": "Client B"}');
+INSERT 0 2
+-- Validate the structure, spock.tables catalog table and data
+\d projects
+                        Table "public.projects"
+    Column    |          Type          | Collation | Nullable | Default 
+--------------+------------------------+-----------+----------+---------
+ project_id   | integer                |           | not null | 
+ project_name | character varying(100) |           | not null | 
+ start_date   | date                   |           |          | 
+ end_date     | date                   |           |          | 
+ budget       | numeric(12,2)          |           |          | 
+ active       | boolean                |           |          | 
+ metadata     | json                   |           |          | 
+Indexes:
+    "projects_pkey" PRIMARY KEY, btree (project_id)
+Check constraints:
+    "projects_budget_check" CHECK (budget > 0::numeric)
+
+EXECUTE spocktab('projects');
+ nspname | relname  | set_name 
+---------+----------+----------
+ public  | projects | default
+(1 row)
+
+-- Create a table for employee projects (many-to-many relationship)
+CREATE TABLE employee_projects (
+    emp_id INT,
+    project_id INT,
+    hours_worked NUMERIC(5, 2),
+    role VARCHAR(50),
+    PRIMARY KEY (emp_id, project_id),
+    FOREIGN KEY (emp_id) REFERENCES employees (emp_id),
+    FOREIGN KEY (project_id) REFERENCES projects (project_id)
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into employee_projects table
+INSERT INTO employee_projects (emp_id, project_id, hours_worked, role) VALUES
+(1, 1, 120.5, 'Manager'),
+(2, 1, 80.0, 'Developer'),
+(3, 2, 150.75, 'Lead Developer');
+INSERT 0 3
+-- Validate the structure, spock.tables catalog table and data
+\d employee_projects
+                   Table "public.employee_projects"
+    Column    |         Type          | Collation | Nullable | Default 
+--------------+-----------------------+-----------+----------+---------
+ emp_id       | integer               |           | not null | 
+ project_id   | integer               |           | not null | 
+ hours_worked | numeric(5,2)          |           |          | 
+ role         | character varying(50) |           |          | 
+Indexes:
+    "employee_projects_pkey" PRIMARY KEY, btree (emp_id, project_id)
+Foreign-key constraints:
+    "employee_projects_emp_id_fkey" FOREIGN KEY (emp_id) REFERENCES employees(emp_id)
+    "employee_projects_project_id_fkey" FOREIGN KEY (project_id) REFERENCES projects(project_id)
+
+EXECUTE spocktab('employee_projects');
+ nspname |      relname      | set_name 
+---------+-------------------+----------
+ public  | employee_projects | default
+(1 row)
+
+-- Create additional tables to cover more data types and constraints
+CREATE TABLE products (
+    product_id INT PRIMARY KEY,
+    product_name VARCHAR(100),
+    price NUMERIC(10, 2),
+    stock_quantity INT,
+    discontinued BOOLEAN,
+    product_description TEXT,
+    added TIMESTAMP WITHOUT TIME ZONE,
+    updated TIMESTAMPTZ
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into products table
+INSERT INTO products (product_id, product_name, price, stock_quantity, discontinued, product_description, added, updated) VALUES
+(1, 'Product A', 19.99, 100, FALSE, 'Description of Product A', '2023-01-01 12:00:00', '2023-01-01 12:00:00+00'),
+(2, 'Product B', 29.99, 200, TRUE, 'Description of Product B', '2023-02-01 15:00:00', '2023-02-01 15:00:00+00');
+INSERT 0 2
+-- Validate the structure, spock.tables catalog table and data
+\d products
+                              Table "public.products"
+       Column        |            Type             | Collation | Nullable | Default 
+---------------------+-----------------------------+-----------+----------+---------
+ product_id          | integer                     |           | not null | 
+ product_name        | character varying(100)      |           |          | 
+ price               | numeric(10,2)               |           |          | 
+ stock_quantity      | integer                     |           |          | 
+ discontinued        | boolean                     |           |          | 
+ product_description | text                        |           |          | 
+ added               | timestamp without time zone |           |          | 
+ updated             | timestamp with time zone    |           |          | 
+Indexes:
+    "products_pkey" PRIMARY KEY, btree (product_id)
+
+EXECUTE spocktab('products');
+ nspname | relname  | set_name 
+---------+----------+----------
+ public  | products | default
+(1 row)
+
+-- Alter table products to add and modify columns
+ALTER TABLE products ADD COLUMN category VARCHAR(50);
+INFO:  DDL statement replicated.
+ALTER TABLE
+ALTER TABLE products ALTER COLUMN price SET NOT NULL;
+INFO:  DDL statement replicated.
+ALTER TABLE
+ALTER TABLE products ADD CONSTRAINT price_check CHECK (price > 0);
+INFO:  DDL statement replicated.
+ALTER TABLE
+-- Validate the structure, spock.tables catalog table and data
+\d products
+                              Table "public.products"
+       Column        |            Type             | Collation | Nullable | Default 
+---------------------+-----------------------------+-----------+----------+---------
+ product_id          | integer                     |           | not null | 
+ product_name        | character varying(100)      |           |          | 
+ price               | numeric(10,2)               |           | not null | 
+ stock_quantity      | integer                     |           |          | 
+ discontinued        | boolean                     |           |          | 
+ product_description | text                        |           |          | 
+ added               | timestamp without time zone |           |          | 
+ updated             | timestamp with time zone    |           |          | 
+ category            | character varying(50)       |           |          | 
+Indexes:
+    "products_pkey" PRIMARY KEY, btree (product_id)
+Check constraints:
+    "price_check" CHECK (price > 0::numeric)
+
+EXECUTE spocktab('products');
+ nspname | relname  | set_name 
+---------+----------+----------
+ public  | products | default
+(1 row)
+
+-- Update product data
+UPDATE products SET stock_quantity = 150 WHERE product_id = 1;
+UPDATE 1
+-- Create additional tables with case-sensitive names and special characters
+CREATE TABLE "CaseSensitiveTable" (
+    "ID" INT PRIMARY KEY,
+    "Name" VARCHAR(50),
+    "Value" NUMERIC(10, 2)
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into CaseSensitiveTable
+INSERT INTO "CaseSensitiveTable" ("ID", "Name", "Value") VALUES
+(1, 'Item One', 123.45),
+(2, 'Item Two', 678.90);
+INSERT 0 2
+-- Validate the structure, spock.tables catalog table and data
+\d "CaseSensitiveTable"
+                Table "public.CaseSensitiveTable"
+ Column |         Type          | Collation | Nullable | Default 
+--------+-----------------------+-----------+----------+---------
+ ID     | integer               |           | not null | 
+ Name   | character varying(50) |           |          | 
+ Value  | numeric(10,2)         |           |          | 
+Indexes:
+    "CaseSensitiveTable_pkey" PRIMARY KEY, btree ("ID")
+
+EXECUTE spocktab('CaseSensitiveTable');
+ nspname |      relname       | set_name 
+---------+--------------------+----------
+ public  | CaseSensitiveTable | default
+(1 row)
+
+-- Create table to test various ALTER TABLE operations
+CREATE TABLE test_tab1 (
+    id UUID PRIMARY KEY,
+    data VARCHAR(100)
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into test_tab1
+INSERT INTO test_tab1 (id, data) VALUES ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'Initial data');
+INSERT 0 1
+-- Alter table test_tab1 to add, drop, and rename columns
+ALTER TABLE test_tab1 ADD COLUMN new_data TEXT;
+INFO:  DDL statement replicated.
+ALTER TABLE
+ALTER TABLE test_tab1 DROP COLUMN new_data;
+INFO:  DDL statement replicated.
+ALTER TABLE
+ALTER TABLE test_tab1 RENAME COLUMN data TO old_data;
+INFO:  DDL statement replicated.
+ALTER TABLE
+-- Validate the structure, spock.tables catalog table and data
+\d test_tab1
+                      Table "public.test_tab1"
+  Column  |          Type          | Collation | Nullable | Default 
+----------+------------------------+-----------+----------+---------
+ id       | uuid                   |           | not null | 
+ old_data | character varying(100) |           |          | 
+Indexes:
+    "test_tab1_pkey" PRIMARY KEY, btree (id)
+
+EXECUTE spocktab('test_tab1');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | test_tab1 | default
+(1 row)
+
+-- Create table to test more data types and constraints
+CREATE TABLE test_tab2 (
+    id INT PRIMARY KEY,
+    timestamp_col TIMESTAMPTZ,
+    interval_col INTERVAL,
+    inet_col INET,
+    cidr_col CIDR,
+    macaddr_col MACADDR,
+    bit_col BIT(8),
+    varbit_col VARBIT(8),
+    box_col BOX,
+    circle_col CIRCLE,
+    line_col LINE,
+    lseg_col LSEG,
+    path_col PATH,
+    polygon_col POLYGON
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into test_tab2
+INSERT INTO test_tab2 (id, timestamp_col, interval_col, inet_col, cidr_col, macaddr_col, bit_col, varbit_col, box_col, circle_col, line_col, lseg_col, path_col, polygon_col) VALUES
+(1, '2023-01-01 12:00:00+00', '1 year 2 months', '192.168.1.1', '192.168.0.0/24', '08:00:2b:01:02:03', B'10101010', B'10101010', '((0,0),(1,1))', '<(1,1),1>', '{1,2,3}', '((0,0),(1,1))', '((0,0),(1,1))', '((0,0),(1,1))');
+INSERT 0 1
+-- Validate the structure, spock.tables catalog table and data
+\d test_tab2
+                         Table "public.test_tab2"
+    Column     |           Type           | Collation | Nullable | Default 
+---------------+--------------------------+-----------+----------+---------
+ id            | integer                  |           | not null | 
+ timestamp_col | timestamp with time zone |           |          | 
+ interval_col  | interval                 |           |          | 
+ inet_col      | inet                     |           |          | 
+ cidr_col      | cidr                     |           |          | 
+ macaddr_col   | macaddr                  |           |          | 
+ bit_col       | bit(8)                   |           |          | 
+ varbit_col    | bit varying(8)           |           |          | 
+ box_col       | box                      |           |          | 
+ circle_col    | circle                   |           |          | 
+ line_col      | line                     |           |          | 
+ lseg_col      | lseg                     |           |          | 
+ path_col      | path                     |           |          | 
+ polygon_col   | polygon                  |           |          | 
+Indexes:
+    "test_tab2_pkey" PRIMARY KEY, btree (id)
+
+EXECUTE spocktab('test_tab2');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | test_tab2 | default
+(1 row)
+
+-- Create table to test composite and array types
+CREATE TABLE test_tab3 (
+    id INT PRIMARY KEY,
+    name VARCHAR(100),
+    int_array INT[],
+    text_array TEXT[]
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into test_tab3 
+INSERT INTO test_tab3 (id, name, int_array, text_array) VALUES
+(1, 'Henry', '{1,2,3}', '{"one","two","three"}'),
+(2, 'Isabel', '{4,5,6}', '{"four","five","six"}');
+INSERT 0 2
+-- Validate the structure, spock.tables catalog table and data
+\d test_tab3
+                       Table "public.test_tab3"
+   Column   |          Type          | Collation | Nullable | Default 
+------------+------------------------+-----------+----------+---------
+ id         | integer                |           | not null | 
+ name       | character varying(100) |           |          | 
+ int_array  | integer[]              |           |          | 
+ text_array | text[]                 |           |          | 
+Indexes:
+    "test_tab3_pkey" PRIMARY KEY, btree (id)
+
+EXECUTE spocktab('test_tab3');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | test_tab3 | default
+(1 row)
+
+-- creating table without primary key to ensure the default repset is default_insert_only
+-- and then play around with adding primary key and dropping them to see the repset
+-- are set accordingly. 
+-- Create the initial table
+CREATE TABLE test_tab4 (
+    id TEXT,
+    data VARCHAR(100)
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into test_tab4
+INSERT INTO test_tab4 (id, data) VALUES ('m2eebc99', 'Initial data');
+INSERT 0 1
+-- Execute prepared statement for the table, repset default_insert_only
+EXECUTE spocktab('test_tab4');
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | test_tab4 | default_insert_only
+(1 row)
+
+-- Alter table to add a primary key on the id column
+ALTER TABLE test_tab4 ADD PRIMARY KEY (id);
+INFO:  DDL statement replicated.
+ALTER TABLE
+-- Display the table structure
+\d test_tab4
+                     Table "public.test_tab4"
+ Column |          Type          | Collation | Nullable | Default 
+--------+------------------------+-----------+----------+---------
+ id     | text                   |           | not null | 
+ data   | character varying(100) |           |          | 
+Indexes:
+    "test_tab4_pkey" PRIMARY KEY, btree (id)
+
+-- Execute prepared statement for the table, repset default
+EXECUTE spocktab('test_tab4');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | test_tab4 | default
+(1 row)
+
+-- Alter table to remove primary key
+ALTER TABLE test_tab4 DROP CONSTRAINT test_tab4_pkey;
+INFO:  DDL statement replicated.
+ALTER TABLE
+-- Alter table to add, drop, and rename columns
+ALTER TABLE test_tab4 ADD COLUMN new_data TEXT;
+INFO:  DDL statement replicated.
+ALTER TABLE
+ALTER TABLE test_tab4 DROP COLUMN new_data;
+INFO:  DDL statement replicated.
+ALTER TABLE
+ALTER TABLE test_tab4 RENAME COLUMN data TO old_data;
+INFO:  DDL statement replicated.
+ALTER TABLE
+-- Display the table structure
+\d test_tab4
+                      Table "public.test_tab4"
+  Column  |          Type          | Collation | Nullable | Default 
+----------+------------------------+-----------+----------+---------
+ id       | text                   |           | not null | 
+ old_data | character varying(100) |           |          | 
+
+-- Execute prepared statement again for the table
+EXECUTE spocktab('test_tab4');
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | test_tab4 | default_insert_only
+(1 row)
+
+-- Alter table to add a primary key on multiple columns
+ALTER TABLE test_tab4 ADD PRIMARY KEY (id, old_data);
+INFO:  DDL statement replicated.
+ALTER TABLE
+-- Display the table structure
+\d test_tab4
+                      Table "public.test_tab4"
+  Column  |          Type          | Collation | Nullable | Default 
+----------+------------------------+-----------+----------+---------
+ id       | text                   |           | not null | 
+ old_data | character varying(100) |           | not null | 
+Indexes:
+    "test_tab4_pkey" PRIMARY KEY, btree (id, old_data)
+
+-- Execute prepared statement again for the table
+EXECUTE spocktab('test_tab4');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | test_tab4 | default
+(1 row)
+
+-- Alter table to drop the primary key
+ALTER TABLE test_tab4 DROP CONSTRAINT test_tab4_pkey;
+INFO:  DDL statement replicated.
+ALTER TABLE
+-- Display the table structure
+\d test_tab4
+                      Table "public.test_tab4"
+  Column  |          Type          | Collation | Nullable | Default 
+----------+------------------------+-----------+----------+---------
+ id       | text                   |           | not null | 
+ old_data | character varying(100) |           | not null | 
+
+-- Execute prepared statement again for the table
+EXECUTE spocktab('test_tab4');
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | test_tab4 | default_insert_only
+(1 row)
+
+-- Negative test cases to validate constraints and error handling
+-- Attempt to insert a record with a duplicate primary key (should fail)
+INSERT INTO employees (emp_id, first_name, last_name, email) VALUES (1, 'Duplicate', 'Entry', 'duplicate@example.com'); -- This should produce a primary key violation error
+ERROR:  null value in column "salary" of relation "employees" violates not-null constraint
+DETAIL:  Failing row contains (1, Duplicate, Entry, duplicate@example.com, null, null, null, t, null, null, null, null, null, null).
+-- Attempt to insert a record with a negative salary (should fail due to CHECK constraint)
+INSERT INTO employees (emp_id, first_name, last_name, email, salary) VALUES (3, 'Negative', 'Salary', 'negative@example.com', -5000); -- This should produce a check constraint violation error
+ERROR:  new row for relation "employees" violates check constraint "chk_salary"
+DETAIL:  Failing row contains (3, Negative, Salary, negative@example.com, null, null, -5000.00, t, null, null, null, null, null, null).
+-- Final validation of all tables along with querying the spock.tables
+\d+ employees
+                                                       Table "public.employees"
+     Column      |            Type             | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+-----------------+-----------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ emp_id          | integer                     |           | not null |         | plain    |             |              | 
+ first_name      | character varying(50)       |           | not null |         | extended |             |              | 
+ last_name       | character varying(50)       |           | not null |         | extended |             |              | 
+ email           | character varying(100)      |           | not null |         | extended |             |              | 
+ hire_date       | date                        |           |          |         | plain    |             |              | 
+ birth_time      | time without time zone      |           |          |         | plain    |             |              | 
+ salary          | numeric(10,2)               |           | not null |         | main     |             |              | 
+ full_time       | boolean                     |           |          | true    | plain    |             |              | 
+ address         | text                        |           |          |         | extended |             |              | 
+ metadata        | json                        |           |          |         | extended |             |              | 
+ start_timestamp | timestamp without time zone |           |          |         | plain    |             |              | 
+ emp_coordinates | point                       |           |          |         | plain    |             |              | 
+ middle_name     | character varying(100)      |           |          |         | extended |             |              | 
+ dept_id         | integer                     |           |          |         | plain    |             |              | 
+Indexes:
+    "employees_pkey" PRIMARY KEY, btree (emp_id)
+    "employees_email_key" UNIQUE CONSTRAINT, btree (email)
+Check constraints:
+    "chk_salary" CHECK (salary > 0::numeric)
+Foreign-key constraints:
+    "fk_dept" FOREIGN KEY (dept_id) REFERENCES departments(dept_id)
+Referenced by:
+    TABLE "employee_projects" CONSTRAINT "employee_projects_emp_id_fkey" FOREIGN KEY (emp_id) REFERENCES employees(emp_id)
+Access method: heap
+
+EXECUTE spocktab('employees');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | employees | default
+(1 row)
+
+\d+ departments
+                                                 Table "public.departments"
+   Column    |          Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+-------------+------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ dept_id     | integer                |           | not null |         | plain    |             |              | 
+ dept_name   | character varying(100) |           | not null |         | extended |             |              | 
+ location    | character varying(100) |           |          |         | extended |             |              | 
+ established | date                   |           |          |         | plain    |             |              | 
+ budget      | money                  |           |          |         | plain    |             |              | 
+ active      | boolean                |           |          |         | plain    |             |              | 
+Indexes:
+    "departments_pkey" PRIMARY KEY, btree (dept_id)
+Referenced by:
+    TABLE "employees" CONSTRAINT "fk_dept" FOREIGN KEY (dept_id) REFERENCES departments(dept_id)
+Access method: heap
+
+execute spocktab('departments');
+ nspname |   relname   | set_name 
+---------+-------------+----------
+ public  | departments | default
+(1 row)
+
+\d+ projects
+                                                   Table "public.projects"
+    Column    |          Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------------+------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ project_id   | integer                |           | not null |         | plain    |             |              | 
+ project_name | character varying(100) |           | not null |         | extended |             |              | 
+ start_date   | date                   |           |          |         | plain    |             |              | 
+ end_date     | date                   |           |          |         | plain    |             |              | 
+ budget       | numeric(12,2)          |           |          |         | main     |             |              | 
+ active       | boolean                |           |          |         | plain    |             |              | 
+ metadata     | json                   |           |          |         | extended |             |              | 
+Indexes:
+    "projects_pkey" PRIMARY KEY, btree (project_id)
+Check constraints:
+    "projects_budget_check" CHECK (budget > 0::numeric)
+Referenced by:
+    TABLE "employee_projects" CONSTRAINT "employee_projects_project_id_fkey" FOREIGN KEY (project_id) REFERENCES projects(project_id)
+Access method: heap
+
+execute spocktab('projects');
+ nspname | relname  | set_name 
+---------+----------+----------
+ public  | projects | default
+(1 row)
+
+\d+ employee_projects
+                                              Table "public.employee_projects"
+    Column    |         Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------------+-----------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ emp_id       | integer               |           | not null |         | plain    |             |              | 
+ project_id   | integer               |           | not null |         | plain    |             |              | 
+ hours_worked | numeric(5,2)          |           |          |         | main     |             |              | 
+ role         | character varying(50) |           |          |         | extended |             |              | 
+Indexes:
+    "employee_projects_pkey" PRIMARY KEY, btree (emp_id, project_id)
+Foreign-key constraints:
+    "employee_projects_emp_id_fkey" FOREIGN KEY (emp_id) REFERENCES employees(emp_id)
+    "employee_projects_project_id_fkey" FOREIGN KEY (project_id) REFERENCES projects(project_id)
+Access method: heap
+
+execute spocktab('employee_projects');
+ nspname |      relname      | set_name 
+---------+-------------------+----------
+ public  | employee_projects | default
+(1 row)
+
+\d+ products
+                                                         Table "public.products"
+       Column        |            Type             | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+---------------------+-----------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ product_id          | integer                     |           | not null |         | plain    |             |              | 
+ product_name        | character varying(100)      |           |          |         | extended |             |              | 
+ price               | numeric(10,2)               |           | not null |         | main     |             |              | 
+ stock_quantity      | integer                     |           |          |         | plain    |             |              | 
+ discontinued        | boolean                     |           |          |         | plain    |             |              | 
+ product_description | text                        |           |          |         | extended |             |              | 
+ added               | timestamp without time zone |           |          |         | plain    |             |              | 
+ updated             | timestamp with time zone    |           |          |         | plain    |             |              | 
+ category            | character varying(50)       |           |          |         | extended |             |              | 
+Indexes:
+    "products_pkey" PRIMARY KEY, btree (product_id)
+Check constraints:
+    "price_check" CHECK (price > 0::numeric)
+Access method: heap
+
+execute spocktab('products');
+ nspname | relname  | set_name 
+---------+----------+----------
+ public  | products | default
+(1 row)
+
+\d+ "CaseSensitiveTable"
+                                           Table "public.CaseSensitiveTable"
+ Column |         Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+-----------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ ID     | integer               |           | not null |         | plain    |             |              | 
+ Name   | character varying(50) |           |          |         | extended |             |              | 
+ Value  | numeric(10,2)         |           |          |         | main     |             |              | 
+Indexes:
+    "CaseSensitiveTable_pkey" PRIMARY KEY, btree ("ID")
+Access method: heap
+
+execute spocktab('CaseSensitiveTable');
+ nspname |      relname       | set_name 
+---------+--------------------+----------
+ public  | CaseSensitiveTable | default
+(1 row)
+
+\d+ test_tab1
+                                                 Table "public.test_tab1"
+  Column  |          Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+----------+------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id       | uuid                   |           | not null |         | plain    |             |              | 
+ old_data | character varying(100) |           |          |         | extended |             |              | 
+Indexes:
+    "test_tab1_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+execute spocktab('test_tab1');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | test_tab1 | default
+(1 row)
+
+\d+ test_tab2
+                                                    Table "public.test_tab2"
+    Column     |           Type           | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+---------------+--------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id            | integer                  |           | not null |         | plain    |             |              | 
+ timestamp_col | timestamp with time zone |           |          |         | plain    |             |              | 
+ interval_col  | interval                 |           |          |         | plain    |             |              | 
+ inet_col      | inet                     |           |          |         | main     |             |              | 
+ cidr_col      | cidr                     |           |          |         | main     |             |              | 
+ macaddr_col   | macaddr                  |           |          |         | plain    |             |              | 
+ bit_col       | bit(8)                   |           |          |         | extended |             |              | 
+ varbit_col    | bit varying(8)           |           |          |         | extended |             |              | 
+ box_col       | box                      |           |          |         | plain    |             |              | 
+ circle_col    | circle                   |           |          |         | plain    |             |              | 
+ line_col      | line                     |           |          |         | plain    |             |              | 
+ lseg_col      | lseg                     |           |          |         | plain    |             |              | 
+ path_col      | path                     |           |          |         | extended |             |              | 
+ polygon_col   | polygon                  |           |          |         | extended |             |              | 
+Indexes:
+    "test_tab2_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+execute spocktab('test_tab2');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | test_tab2 | default
+(1 row)
+
+\d+ test_tab3
+                                                  Table "public.test_tab3"
+   Column   |          Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+------------+------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id         | integer                |           | not null |         | plain    |             |              | 
+ name       | character varying(100) |           |          |         | extended |             |              | 
+ int_array  | integer[]              |           |          |         | extended |             |              | 
+ text_array | text[]                 |           |          |         | extended |             |              | 
+Indexes:
+    "test_tab3_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+execute spocktab('test_tab3');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | test_tab3 | default
+(1 row)
+
+\d+ test_tab4
+                                                 Table "public.test_tab4"
+  Column  |          Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+----------+------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id       | text                   |           | not null |         | extended |             |              | 
+ old_data | character varying(100) |           | not null |         | extended |             |              | 
+Access method: heap
+
+EXECUTE spocktab('test_tab4');
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | test_tab4 | default_insert_only
+(1 row)
+
+-- Validating data in all tables
+SELECT * FROM employees ORDER BY emp_id;
+ emp_id | first_name | last_name |          email          | hire_date  | birth_time |  salary  | full_time |   address    |           metadata            |   start_timestamp   | emp_coordinates | middle_name | dept_id 
+--------+------------+-----------+-------------------------+------------+------------+----------+-----------+--------------+-------------------------------+---------------------+-----------------+-------------+---------
+      1 | John       | Doe       | john.doe@example.com    | 2023-01-15 | 08:30:00   | 60000.00 | t         | 123 Main St  | {"department": "HR"}          | 2023-01-15 08:30:00 | (10,20)         |             |        
+      2 | Jane       | Smith     | jane.smith@example.com  | 2023-03-22 | 09:00:00   | 65000.00 | f         | 456 Elm St   | {"department": "Engineering"} | 2023-03-22 09:00:00 | (30,40)         |             |        
+      3 | Alice      | Brown     | alice.brown@example.com | 2023-05-10 | 07:45:00   | 70000.00 | t         | 789 Maple St | {"department": "Engineering"} | 2023-05-10 07:45:00 | (50,60)         | M           |       2
+      4 | Bob        | Johnson   | bob.johnson@example.com | 2023-02-20 | 10:00:00   | 62000.00 | f         | 101 Pine St  | {"department": "HR"}          | 2023-02-20 10:00:00 | (70,80)         | J           |       1
+(4 rows)
+
+SELECT * FROM departments ORDER BY dept_id;
+ dept_id |    dept_name    |   location    | established |    budget     | active 
+---------+-----------------+---------------+-------------+---------------+--------
+       1 | Human Resources | New York      | 2010-01-01  | $1,000,000.00 | t
+       2 | Engineering     | San Francisco | 2015-06-15  | $2,000,000.00 | t
+(2 rows)
+
+SELECT * FROM projects ORDER BY project_id;
+ project_id | project_name  | start_date |  end_date  |  budget   | active |        metadata        
+------------+---------------+------------+------------+-----------+--------+------------------------
+          1 | Project Alpha | 2023-01-01 | 2023-06-30 | 500000.00 | t      | {"client": "Client A"}
+          2 | Project Beta  | 2023-02-15 | 2023-12-31 | 750000.00 | t      | {"client": "Client B"}
+(2 rows)
+
+SELECT * FROM employee_projects ORDER BY emp_id, project_id;
+ emp_id | project_id | hours_worked |      role      
+--------+------------+--------------+----------------
+      1 |          1 |       120.50 | Manager
+      2 |          1 |        80.00 | Developer
+      3 |          2 |       150.75 | Lead Developer
+(3 rows)
+
+SELECT * FROM products ORDER BY product_id;
+ product_id | product_name | price | stock_quantity | discontinued |   product_description    |        added        |        updated         | category 
+------------+--------------+-------+----------------+--------------+--------------------------+---------------------+------------------------+----------
+          1 | Product A    | 19.99 |            150 | f            | Description of Product A | 2023-01-01 12:00:00 | 2023-01-01 17:00:00+05 | 
+          2 | Product B    | 29.99 |            200 | t            | Description of Product B | 2023-02-01 15:00:00 | 2023-02-01 20:00:00+05 | 
+(2 rows)
+
+SELECT * FROM "CaseSensitiveTable" ORDER BY "ID";
+ ID |   Name   | Value  
+----+----------+--------
+  1 | Item One | 123.45
+  2 | Item Two | 678.90
+(2 rows)
+
+SELECT * FROM test_tab1 ORDER BY id;
+                  id                  |   old_data   
+--------------------------------------+--------------
+ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | Initial data
+(1 row)
+
+SELECT * FROM test_tab2 ORDER BY id;
+ id |     timestamp_col      | interval_col  |  inet_col   |    cidr_col    |    macaddr_col    | bit_col  | varbit_col |   box_col   | circle_col | line_col |   lseg_col    |   path_col    |  polygon_col  
+----+------------------------+---------------+-------------+----------------+-------------------+----------+------------+-------------+------------+----------+---------------+---------------+---------------
+  1 | 2023-01-01 17:00:00+05 | 1 year 2 mons | 192.168.1.1 | 192.168.0.0/24 | 08:00:2b:01:02:03 | 10101010 | 10101010   | (1,1),(0,0) | <(1,1),1>  | {1,2,3}  | [(0,0),(1,1)] | ((0,0),(1,1)) | ((0,0),(1,1))
+(1 row)
+
+SELECT * FROM test_tab3 ORDER BY id;
+ id |  name  | int_array |   text_array    
+----+--------+-----------+-----------------
+  1 | Henry  | {1,2,3}   | {one,two,three}
+  2 | Isabel | {4,5,6}   | {four,five,six}
+(2 rows)
+
+SELECT * FROM test_tab4 ORDER BY id;
+    id    |   old_data   
+----------+--------------
+ m2eebc99 | Initial data
+(1 row)
+

--- a/test/t/auto_ddl/6100a_table_datatypes_create_alter_n1.sql
+++ b/test/t/auto_ddl/6100a_table_datatypes_create_alter_n1.sql
@@ -1,0 +1,320 @@
+-- 6100a_create_alter_table_n1.sql
+-- This script creates and alters tables on node n1 to test the autoDDL functionality.
+-- It includes a wide variety of data types and exercises several CREATE TABLE/ ALTER TABLE DDL constructs.
+-- Also regularly verifying spock.tables 
+
+-- Prepared statement for spock.tables so that we can execute it frequently in the script below
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname = $1 ORDER BY relid;
+
+-- Create a table for employee details with various data types
+CREATE TABLE employees (
+    emp_id INT PRIMARY KEY,
+    first_name VARCHAR(50) NOT NULL,
+    last_name VARCHAR(50) NOT NULL,
+    email VARCHAR(100) UNIQUE NOT NULL,
+    hire_date DATE,
+    birth_time TIME WITHOUT TIME ZONE,
+    salary NUMERIC(10, 2),
+    full_time BOOLEAN DEFAULT TRUE,
+    street_address TEXT,
+    metadata JSON,
+    start_timestamp TIMESTAMP WITHOUT TIME ZONE,
+    emp_coordinates POINT,
+    CONSTRAINT chk_salary CHECK (salary > 0)
+);
+
+-- Insert initial data into employees table
+INSERT INTO employees (emp_id, first_name, last_name, email, hire_date, birth_time, salary, full_time, street_address, metadata, start_timestamp, emp_coordinates) VALUES
+(1, 'John', 'Doe', 'john.doe@example.com', '2023-01-15', '08:30:00', 60000, TRUE, '123 Main St', '{"department": "HR"}', '2023-01-15 08:30:00', '(10, 20)'),
+(2, 'Jane', 'Smith', 'jane.smith@example.com', '2023-03-22', '09:00:00', 65000, FALSE, '456 Elm St', '{"department": "Engineering"}', '2023-03-22 09:00:00', '(30, 40)');
+
+-- Validate the structure, spock.tables catalog table and data
+\d employees
+EXECUTE spocktab('employees');
+
+-- Create a table for department details
+CREATE TABLE departments (
+    dept_id INT PRIMARY KEY,
+    dept_name VARCHAR(100) NOT NULL,
+    location VARCHAR(100),
+    established DATE,
+    budget MONEY,
+    active BOOLEAN
+);
+
+-- Insert initial data into departments table
+INSERT INTO departments (dept_id, dept_name, location, established, budget, active) VALUES
+(1, 'Human Resources', 'New York', '2010-01-01', '$1000000', TRUE),
+(2, 'Engineering', 'San Francisco', '2015-06-15', '$2000000', TRUE);
+
+-- Validate the structure, spock.tables catalog table and data
+\d departments
+EXECUTE spocktab('departments');
+
+-- Alter table employees to add new columns, modify existing columns, and add constraints
+ALTER TABLE employees ADD COLUMN middle_name VARCHAR(100);
+ALTER TABLE employees ADD COLUMN dept_id INT;
+ALTER TABLE employees ADD CONSTRAINT fk_dept FOREIGN KEY (dept_id) REFERENCES departments (dept_id);
+ALTER TABLE employees ALTER COLUMN salary SET NOT NULL;
+ALTER TABLE employees RENAME COLUMN street_address TO address;
+
+-- Validate the structure, spock.tables catalog table and data
+\d employees
+EXECUTE spocktab('employees');
+
+-- Insert additional data with new columns
+INSERT INTO employees (emp_id, first_name, middle_name, last_name, email, hire_date, birth_time, salary, full_time, address, metadata, start_timestamp, emp_coordinates, dept_id) VALUES
+(3, 'Alice', 'M', 'Brown', 'alice.brown@example.com', '2023-05-10', '07:45:00', 70000, TRUE, '789 Maple St', '{"department": "Engineering"}', '2023-05-10 07:45:00', '(50, 60)', 2),
+(4, 'Bob', 'J', 'Johnson', 'bob.johnson@example.com', '2023-02-20', '10:00:00', 62000, FALSE, '101 Pine St', '{"department": "HR"}', '2023-02-20 10:00:00', '(70, 80)', 1);
+
+-- Create more tables to cover various types and constraints
+CREATE TABLE projects (
+    project_id INT PRIMARY KEY,
+    project_name VARCHAR(100) NOT NULL,
+    start_date DATE,
+    end_date DATE,
+    budget NUMERIC(12, 2) CHECK (budget > 0),
+    active BOOLEAN,
+    metadata JSON
+);
+
+-- Insert initial data into projects table
+INSERT INTO projects (project_id, project_name, start_date, end_date, budget, active, metadata) VALUES
+(1, 'Project Alpha', '2023-01-01', '2023-06-30', 500000.00, TRUE, '{"client": "Client A"}'),
+(2, 'Project Beta', '2023-02-15', '2023-12-31', 750000.00, TRUE, '{"client": "Client B"}');
+
+-- Validate the structure, spock.tables catalog table and data
+\d projects
+EXECUTE spocktab('projects');
+
+-- Create a table for employee projects (many-to-many relationship)
+CREATE TABLE employee_projects (
+    emp_id INT,
+    project_id INT,
+    hours_worked NUMERIC(5, 2),
+    role VARCHAR(50),
+    PRIMARY KEY (emp_id, project_id),
+    FOREIGN KEY (emp_id) REFERENCES employees (emp_id),
+    FOREIGN KEY (project_id) REFERENCES projects (project_id)
+);
+
+-- Insert initial data into employee_projects table
+INSERT INTO employee_projects (emp_id, project_id, hours_worked, role) VALUES
+(1, 1, 120.5, 'Manager'),
+(2, 1, 80.0, 'Developer'),
+(3, 2, 150.75, 'Lead Developer');
+
+-- Validate the structure, spock.tables catalog table and data
+\d employee_projects
+EXECUTE spocktab('employee_projects');
+
+-- Create additional tables to cover more data types and constraints
+CREATE TABLE products (
+    product_id INT PRIMARY KEY,
+    product_name VARCHAR(100),
+    price NUMERIC(10, 2),
+    stock_quantity INT,
+    discontinued BOOLEAN,
+    product_description TEXT,
+    added TIMESTAMP WITHOUT TIME ZONE,
+    updated TIMESTAMPTZ
+);
+
+-- Insert initial data into products table
+INSERT INTO products (product_id, product_name, price, stock_quantity, discontinued, product_description, added, updated) VALUES
+(1, 'Product A', 19.99, 100, FALSE, 'Description of Product A', '2023-01-01 12:00:00', '2023-01-01 12:00:00+00'),
+(2, 'Product B', 29.99, 200, TRUE, 'Description of Product B', '2023-02-01 15:00:00', '2023-02-01 15:00:00+00');
+
+-- Validate the structure, spock.tables catalog table and data
+\d products
+EXECUTE spocktab('products');
+
+-- Alter table products to add and modify columns
+ALTER TABLE products ADD COLUMN category VARCHAR(50);
+ALTER TABLE products ALTER COLUMN price SET NOT NULL;
+ALTER TABLE products ADD CONSTRAINT price_check CHECK (price > 0);
+
+-- Validate the structure, spock.tables catalog table and data
+\d products
+EXECUTE spocktab('products');
+
+-- Update product data
+UPDATE products SET stock_quantity = 150 WHERE product_id = 1;
+
+-- Create additional tables with case-sensitive names and special characters
+CREATE TABLE "CaseSensitiveTable" (
+    "ID" INT PRIMARY KEY,
+    "Name" VARCHAR(50),
+    "Value" NUMERIC(10, 2)
+);
+
+-- Insert initial data into CaseSensitiveTable
+INSERT INTO "CaseSensitiveTable" ("ID", "Name", "Value") VALUES
+(1, 'Item One', 123.45),
+(2, 'Item Two', 678.90);
+
+-- Validate the structure, spock.tables catalog table and data
+\d "CaseSensitiveTable"
+EXECUTE spocktab('CaseSensitiveTable');
+
+-- Create table to test various ALTER TABLE operations
+CREATE TABLE test_tab1 (
+    id UUID PRIMARY KEY,
+    data VARCHAR(100)
+);
+
+-- Insert initial data into test_tab1
+INSERT INTO test_tab1 (id, data) VALUES ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'Initial data');
+
+-- Alter table test_tab1 to add, drop, and rename columns
+ALTER TABLE test_tab1 ADD COLUMN new_data TEXT;
+ALTER TABLE test_tab1 DROP COLUMN new_data;
+ALTER TABLE test_tab1 RENAME COLUMN data TO old_data;
+
+-- Validate the structure, spock.tables catalog table and data
+\d test_tab1
+EXECUTE spocktab('test_tab1');
+
+-- Create table to test more data types and constraints
+CREATE TABLE test_tab2 (
+    id INT PRIMARY KEY,
+    timestamp_col TIMESTAMPTZ,
+    interval_col INTERVAL,
+    inet_col INET,
+    cidr_col CIDR,
+    macaddr_col MACADDR,
+    bit_col BIT(8),
+    varbit_col VARBIT(8),
+    box_col BOX,
+    circle_col CIRCLE,
+    line_col LINE,
+    lseg_col LSEG,
+    path_col PATH,
+    polygon_col POLYGON
+);
+
+-- Insert initial data into test_tab2
+INSERT INTO test_tab2 (id, timestamp_col, interval_col, inet_col, cidr_col, macaddr_col, bit_col, varbit_col, box_col, circle_col, line_col, lseg_col, path_col, polygon_col) VALUES
+(1, '2023-01-01 12:00:00+00', '1 year 2 months', '192.168.1.1', '192.168.0.0/24', '08:00:2b:01:02:03', B'10101010', B'10101010', '((0,0),(1,1))', '<(1,1),1>', '{1,2,3}', '((0,0),(1,1))', '((0,0),(1,1))', '((0,0),(1,1))');
+
+-- Validate the structure, spock.tables catalog table and data
+\d test_tab2
+EXECUTE spocktab('test_tab2');
+
+-- Create table to test composite and array types
+CREATE TABLE test_tab3 (
+    id INT PRIMARY KEY,
+    name VARCHAR(100),
+    int_array INT[],
+    text_array TEXT[]
+);
+
+-- Insert initial data into test_tab3 
+INSERT INTO test_tab3 (id, name, int_array, text_array) VALUES
+(1, 'Henry', '{1,2,3}', '{"one","two","three"}'),
+(2, 'Isabel', '{4,5,6}', '{"four","five","six"}');
+
+-- Validate the structure, spock.tables catalog table and data
+\d test_tab3
+EXECUTE spocktab('test_tab3');
+
+-- creating table without primary key to ensure the default repset is default_insert_only
+-- and then play around with adding primary key and dropping them to see the repset
+-- are set accordingly. 
+
+-- Create the initial table
+CREATE TABLE test_tab4 (
+    id TEXT,
+    data VARCHAR(100)
+);
+
+-- Insert initial data into test_tab4
+INSERT INTO test_tab4 (id, data) VALUES ('m2eebc99', 'Initial data');
+-- Execute prepared statement for the table, repset default_insert_only
+EXECUTE spocktab('test_tab4');
+-- Alter table to add a primary key on the id column
+ALTER TABLE test_tab4 ADD PRIMARY KEY (id);
+
+-- Display the table structure
+\d test_tab4
+-- Execute prepared statement for the table, repset default
+EXECUTE spocktab('test_tab4');
+
+-- Alter table to remove primary key
+ALTER TABLE test_tab4 DROP CONSTRAINT test_tab4_pkey;
+
+-- Alter table to add, drop, and rename columns
+ALTER TABLE test_tab4 ADD COLUMN new_data TEXT;
+ALTER TABLE test_tab4 DROP COLUMN new_data;
+ALTER TABLE test_tab4 RENAME COLUMN data TO old_data;
+
+-- Display the table structure
+\d test_tab4
+-- Execute prepared statement again for the table
+EXECUTE spocktab('test_tab4');
+
+-- Alter table to add a primary key on multiple columns
+ALTER TABLE test_tab4 ADD PRIMARY KEY (id, old_data);
+
+-- Display the table structure
+\d test_tab4
+-- Execute prepared statement again for the table
+EXECUTE spocktab('test_tab4');
+
+-- Alter table to drop the primary key
+ALTER TABLE test_tab4 DROP CONSTRAINT test_tab4_pkey;
+
+-- Display the table structure
+\d test_tab4
+-- Execute prepared statement again for the table
+EXECUTE spocktab('test_tab4');
+
+-- Negative test cases to validate constraints and error handling
+-- Attempt to insert a record with a duplicate primary key (should fail)
+INSERT INTO employees (emp_id, first_name, last_name, email) VALUES (1, 'Duplicate', 'Entry', 'duplicate@example.com'); -- This should produce a primary key violation error
+
+-- Attempt to insert a record with a negative salary (should fail due to CHECK constraint)
+INSERT INTO employees (emp_id, first_name, last_name, email, salary) VALUES (3, 'Negative', 'Salary', 'negative@example.com', -5000); -- This should produce a check constraint violation error
+
+-- Final validation of all tables along with querying the spock.tables
+\d+ employees
+EXECUTE spocktab('employees');
+
+\d+ departments
+execute spocktab('departments');
+
+\d+ projects
+execute spocktab('projects');
+
+\d+ employee_projects
+execute spocktab('employee_projects');
+
+\d+ products
+execute spocktab('products');
+
+\d+ "CaseSensitiveTable"
+execute spocktab('CaseSensitiveTable');
+
+\d+ test_tab1
+execute spocktab('test_tab1');
+
+\d+ test_tab2
+execute spocktab('test_tab2');
+
+\d+ test_tab3
+execute spocktab('test_tab3');
+
+\d+ test_tab4
+EXECUTE spocktab('test_tab4');
+
+-- Validating data in all tables
+SELECT * FROM employees ORDER BY emp_id;
+SELECT * FROM departments ORDER BY dept_id;
+SELECT * FROM projects ORDER BY project_id;
+SELECT * FROM employee_projects ORDER BY emp_id, project_id;
+SELECT * FROM products ORDER BY product_id;
+SELECT * FROM "CaseSensitiveTable" ORDER BY "ID";
+SELECT * FROM test_tab1 ORDER BY id;
+SELECT * FROM test_tab2 ORDER BY id;
+SELECT * FROM test_tab3 ORDER BY id;
+SELECT * FROM test_tab4 ORDER BY id;

--- a/test/t/auto_ddl/6100b_table_validate_and_drop_n2.out
+++ b/test/t/auto_ddl/6100b_table_validate_and_drop_n2.out
@@ -1,0 +1,343 @@
+-- AutoDDL validation on n2 to ensure all the DDL/DML performed in the 6100a files on n1 
+-- was auto replicated to n2.
+-- In the end, the same objects are dropped.
+-- Prepared statement for spock.tables so that we can execute it frequently in the script below
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname = $1 ORDER BY relid;
+PREPARE
+-- Final validation of all tables along with querying the spock.tables
+\d+ employees
+                                                       Table "public.employees"
+     Column      |            Type             | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+-----------------+-----------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ emp_id          | integer                     |           | not null |         | plain    |             |              | 
+ first_name      | character varying(50)       |           | not null |         | extended |             |              | 
+ last_name       | character varying(50)       |           | not null |         | extended |             |              | 
+ email           | character varying(100)      |           | not null |         | extended |             |              | 
+ hire_date       | date                        |           |          |         | plain    |             |              | 
+ birth_time      | time without time zone      |           |          |         | plain    |             |              | 
+ salary          | numeric(10,2)               |           | not null |         | main     |             |              | 
+ full_time       | boolean                     |           |          | true    | plain    |             |              | 
+ address         | text                        |           |          |         | extended |             |              | 
+ metadata        | json                        |           |          |         | extended |             |              | 
+ start_timestamp | timestamp without time zone |           |          |         | plain    |             |              | 
+ emp_coordinates | point                       |           |          |         | plain    |             |              | 
+ middle_name     | character varying(100)      |           |          |         | extended |             |              | 
+ dept_id         | integer                     |           |          |         | plain    |             |              | 
+Indexes:
+    "employees_pkey" PRIMARY KEY, btree (emp_id)
+    "employees_email_key" UNIQUE CONSTRAINT, btree (email)
+Check constraints:
+    "chk_salary" CHECK (salary > 0::numeric)
+Foreign-key constraints:
+    "fk_dept" FOREIGN KEY (dept_id) REFERENCES departments(dept_id)
+Referenced by:
+    TABLE "employee_projects" CONSTRAINT "employee_projects_emp_id_fkey" FOREIGN KEY (emp_id) REFERENCES employees(emp_id)
+Access method: heap
+
+EXECUTE spocktab('employees');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | employees | default
+(1 row)
+
+\d+ departments
+                                                 Table "public.departments"
+   Column    |          Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+-------------+------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ dept_id     | integer                |           | not null |         | plain    |             |              | 
+ dept_name   | character varying(100) |           | not null |         | extended |             |              | 
+ location    | character varying(100) |           |          |         | extended |             |              | 
+ established | date                   |           |          |         | plain    |             |              | 
+ budget      | money                  |           |          |         | plain    |             |              | 
+ active      | boolean                |           |          |         | plain    |             |              | 
+Indexes:
+    "departments_pkey" PRIMARY KEY, btree (dept_id)
+Referenced by:
+    TABLE "employees" CONSTRAINT "fk_dept" FOREIGN KEY (dept_id) REFERENCES departments(dept_id)
+Access method: heap
+
+execute spocktab('departments');
+ nspname |   relname   | set_name 
+---------+-------------+----------
+ public  | departments | default
+(1 row)
+
+\d+ projects
+                                                   Table "public.projects"
+    Column    |          Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------------+------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ project_id   | integer                |           | not null |         | plain    |             |              | 
+ project_name | character varying(100) |           | not null |         | extended |             |              | 
+ start_date   | date                   |           |          |         | plain    |             |              | 
+ end_date     | date                   |           |          |         | plain    |             |              | 
+ budget       | numeric(12,2)          |           |          |         | main     |             |              | 
+ active       | boolean                |           |          |         | plain    |             |              | 
+ metadata     | json                   |           |          |         | extended |             |              | 
+Indexes:
+    "projects_pkey" PRIMARY KEY, btree (project_id)
+Check constraints:
+    "projects_budget_check" CHECK (budget > 0::numeric)
+Referenced by:
+    TABLE "employee_projects" CONSTRAINT "employee_projects_project_id_fkey" FOREIGN KEY (project_id) REFERENCES projects(project_id)
+Access method: heap
+
+execute spocktab('projects');
+ nspname | relname  | set_name 
+---------+----------+----------
+ public  | projects | default
+(1 row)
+
+\d+ employee_projects
+                                              Table "public.employee_projects"
+    Column    |         Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------------+-----------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ emp_id       | integer               |           | not null |         | plain    |             |              | 
+ project_id   | integer               |           | not null |         | plain    |             |              | 
+ hours_worked | numeric(5,2)          |           |          |         | main     |             |              | 
+ role         | character varying(50) |           |          |         | extended |             |              | 
+Indexes:
+    "employee_projects_pkey" PRIMARY KEY, btree (emp_id, project_id)
+Foreign-key constraints:
+    "employee_projects_emp_id_fkey" FOREIGN KEY (emp_id) REFERENCES employees(emp_id)
+    "employee_projects_project_id_fkey" FOREIGN KEY (project_id) REFERENCES projects(project_id)
+Access method: heap
+
+execute spocktab('employee_projects');
+ nspname |      relname      | set_name 
+---------+-------------------+----------
+ public  | employee_projects | default
+(1 row)
+
+\d+ products
+                                                         Table "public.products"
+       Column        |            Type             | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+---------------------+-----------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ product_id          | integer                     |           | not null |         | plain    |             |              | 
+ product_name        | character varying(100)      |           |          |         | extended |             |              | 
+ price               | numeric(10,2)               |           | not null |         | main     |             |              | 
+ stock_quantity      | integer                     |           |          |         | plain    |             |              | 
+ discontinued        | boolean                     |           |          |         | plain    |             |              | 
+ product_description | text                        |           |          |         | extended |             |              | 
+ added               | timestamp without time zone |           |          |         | plain    |             |              | 
+ updated             | timestamp with time zone    |           |          |         | plain    |             |              | 
+ category            | character varying(50)       |           |          |         | extended |             |              | 
+Indexes:
+    "products_pkey" PRIMARY KEY, btree (product_id)
+Check constraints:
+    "price_check" CHECK (price > 0::numeric)
+Access method: heap
+
+execute spocktab('products');
+ nspname | relname  | set_name 
+---------+----------+----------
+ public  | products | default
+(1 row)
+
+\d+ "CaseSensitiveTable"
+                                           Table "public.CaseSensitiveTable"
+ Column |         Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+--------+-----------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ ID     | integer               |           | not null |         | plain    |             |              | 
+ Name   | character varying(50) |           |          |         | extended |             |              | 
+ Value  | numeric(10,2)         |           |          |         | main     |             |              | 
+Indexes:
+    "CaseSensitiveTable_pkey" PRIMARY KEY, btree ("ID")
+Access method: heap
+
+execute spocktab('CaseSensitiveTable');
+ nspname |      relname       | set_name 
+---------+--------------------+----------
+ public  | CaseSensitiveTable | default
+(1 row)
+
+\d+ test_tab1
+                                                 Table "public.test_tab1"
+  Column  |          Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+----------+------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id       | uuid                   |           | not null |         | plain    |             |              | 
+ old_data | character varying(100) |           |          |         | extended |             |              | 
+Indexes:
+    "test_tab1_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+execute spocktab('test_tab1');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | test_tab1 | default
+(1 row)
+
+\d+ test_tab2
+                                                    Table "public.test_tab2"
+    Column     |           Type           | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+---------------+--------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id            | integer                  |           | not null |         | plain    |             |              | 
+ timestamp_col | timestamp with time zone |           |          |         | plain    |             |              | 
+ interval_col  | interval                 |           |          |         | plain    |             |              | 
+ inet_col      | inet                     |           |          |         | main     |             |              | 
+ cidr_col      | cidr                     |           |          |         | main     |             |              | 
+ macaddr_col   | macaddr                  |           |          |         | plain    |             |              | 
+ bit_col       | bit(8)                   |           |          |         | extended |             |              | 
+ varbit_col    | bit varying(8)           |           |          |         | extended |             |              | 
+ box_col       | box                      |           |          |         | plain    |             |              | 
+ circle_col    | circle                   |           |          |         | plain    |             |              | 
+ line_col      | line                     |           |          |         | plain    |             |              | 
+ lseg_col      | lseg                     |           |          |         | plain    |             |              | 
+ path_col      | path                     |           |          |         | extended |             |              | 
+ polygon_col   | polygon                  |           |          |         | extended |             |              | 
+Indexes:
+    "test_tab2_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+execute spocktab('test_tab2');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | test_tab2 | default
+(1 row)
+
+\d+ test_tab3
+                                                  Table "public.test_tab3"
+   Column   |          Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+------------+------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id         | integer                |           | not null |         | plain    |             |              | 
+ name       | character varying(100) |           |          |         | extended |             |              | 
+ int_array  | integer[]              |           |          |         | extended |             |              | 
+ text_array | text[]                 |           |          |         | extended |             |              | 
+Indexes:
+    "test_tab3_pkey" PRIMARY KEY, btree (id)
+Access method: heap
+
+execute spocktab('test_tab3');
+ nspname |  relname  | set_name 
+---------+-----------+----------
+ public  | test_tab3 | default
+(1 row)
+
+\d+ test_tab4
+                                                 Table "public.test_tab4"
+  Column  |          Type          | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+----------+------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ id       | text                   |           | not null |         | extended |             |              | 
+ old_data | character varying(100) |           | not null |         | extended |             |              | 
+Access method: heap
+
+EXECUTE spocktab('test_tab4');
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | test_tab4 | default_insert_only
+(1 row)
+
+-- Validating data in all tables
+SELECT * FROM employees ORDER BY emp_id;
+ emp_id | first_name | last_name |          email          | hire_date  | birth_time |  salary  | full_time |   address    |           metadata            |   start_timestamp   | emp_coordinates | middle_name | dept_id 
+--------+------------+-----------+-------------------------+------------+------------+----------+-----------+--------------+-------------------------------+---------------------+-----------------+-------------+---------
+      1 | John       | Doe       | john.doe@example.com    | 2023-01-15 | 08:30:00   | 60000.00 | t         | 123 Main St  | {"department": "HR"}          | 2023-01-15 08:30:00 | (10,20)         |             |        
+      2 | Jane       | Smith     | jane.smith@example.com  | 2023-03-22 | 09:00:00   | 65000.00 | f         | 456 Elm St   | {"department": "Engineering"} | 2023-03-22 09:00:00 | (30,40)         |             |        
+      3 | Alice      | Brown     | alice.brown@example.com | 2023-05-10 | 07:45:00   | 70000.00 | t         | 789 Maple St | {"department": "Engineering"} | 2023-05-10 07:45:00 | (50,60)         | M           |       2
+      4 | Bob        | Johnson   | bob.johnson@example.com | 2023-02-20 | 10:00:00   | 62000.00 | f         | 101 Pine St  | {"department": "HR"}          | 2023-02-20 10:00:00 | (70,80)         | J           |       1
+(4 rows)
+
+SELECT * FROM departments ORDER BY dept_id;
+ dept_id |    dept_name    |   location    | established |    budget     | active 
+---------+-----------------+---------------+-------------+---------------+--------
+       1 | Human Resources | New York      | 2010-01-01  | $1,000,000.00 | t
+       2 | Engineering     | San Francisco | 2015-06-15  | $2,000,000.00 | t
+(2 rows)
+
+SELECT * FROM projects ORDER BY project_id;
+ project_id | project_name  | start_date |  end_date  |  budget   | active |        metadata        
+------------+---------------+------------+------------+-----------+--------+------------------------
+          1 | Project Alpha | 2023-01-01 | 2023-06-30 | 500000.00 | t      | {"client": "Client A"}
+          2 | Project Beta  | 2023-02-15 | 2023-12-31 | 750000.00 | t      | {"client": "Client B"}
+(2 rows)
+
+SELECT * FROM employee_projects ORDER BY emp_id, project_id;
+ emp_id | project_id | hours_worked |      role      
+--------+------------+--------------+----------------
+      1 |          1 |       120.50 | Manager
+      2 |          1 |        80.00 | Developer
+      3 |          2 |       150.75 | Lead Developer
+(3 rows)
+
+SELECT * FROM products ORDER BY product_id;
+ product_id | product_name | price | stock_quantity | discontinued |   product_description    |        added        |        updated         | category 
+------------+--------------+-------+----------------+--------------+--------------------------+---------------------+------------------------+----------
+          1 | Product A    | 19.99 |            150 | f            | Description of Product A | 2023-01-01 12:00:00 | 2023-01-01 17:00:00+05 | 
+          2 | Product B    | 29.99 |            200 | t            | Description of Product B | 2023-02-01 15:00:00 | 2023-02-01 20:00:00+05 | 
+(2 rows)
+
+SELECT * FROM "CaseSensitiveTable" ORDER BY "ID";
+ ID |   Name   | Value  
+----+----------+--------
+  1 | Item One | 123.45
+  2 | Item Two | 678.90
+(2 rows)
+
+SELECT * FROM test_tab1 ORDER BY id;
+                  id                  |   old_data   
+--------------------------------------+--------------
+ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | Initial data
+(1 row)
+
+SELECT * FROM test_tab2 ORDER BY id;
+ id |     timestamp_col      | interval_col  |  inet_col   |    cidr_col    |    macaddr_col    | bit_col  | varbit_col |   box_col   | circle_col | line_col |   lseg_col    |   path_col    |  polygon_col  
+----+------------------------+---------------+-------------+----------------+-------------------+----------+------------+-------------+------------+----------+---------------+---------------+---------------
+  1 | 2023-01-01 17:00:00+05 | 1 year 2 mons | 192.168.1.1 | 192.168.0.0/24 | 08:00:2b:01:02:03 | 10101010 | 10101010   | (1,1),(0,0) | <(1,1),1>  | {1,2,3}  | [(0,0),(1,1)] | ((0,0),(1,1)) | ((0,0),(1,1))
+(1 row)
+
+SELECT * FROM test_tab3 ORDER BY id;
+ id |  name  | int_array |   text_array    
+----+--------+-----------+-----------------
+  1 | Henry  | {1,2,3}   | {one,two,three}
+  2 | Isabel | {4,5,6}   | {four,five,six}
+(2 rows)
+
+SELECT * FROM test_tab4 ORDER BY id;
+    id    |   old_data   
+----------+--------------
+ m2eebc99 | Initial data
+(1 row)
+
+-- Execute drop statements on n2 to exercise DROP TABLE, ensuring it gets replicated.
+-- This also helps with the cleanup
+drop table employees cascade;
+NOTICE:  drop cascades to constraint employee_projects_emp_id_fkey on table employee_projects
+NOTICE:  drop cascades to table employees membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+drop table departments cascade;
+NOTICE:  drop cascades to table departments membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+drop table projects cascade;
+NOTICE:  drop cascades to constraint employee_projects_project_id_fkey on table employee_projects
+NOTICE:  drop cascades to table projects membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+drop table employee_projects cascade;
+NOTICE:  drop cascades to table employee_projects membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+drop table products cascade;
+NOTICE:  drop cascades to table products membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+drop table "CaseSensitiveTable";
+NOTICE:  drop cascades to table "CaseSensitiveTable" membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+drop table test_tab1;
+NOTICE:  drop cascades to table test_tab1 membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+drop table test_tab2;
+NOTICE:  drop cascades to table test_tab2 membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+drop table test_tab3;
+NOTICE:  drop cascades to table test_tab3 membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+drop table test_tab4;
+NOTICE:  drop cascades to table test_tab4 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE

--- a/test/t/auto_ddl/6100b_table_validate_and_drop_n2.sql
+++ b/test/t/auto_ddl/6100b_table_validate_and_drop_n2.sql
@@ -1,0 +1,63 @@
+
+-- AutoDDL validation on n2 to ensure all the DDL/DML performed in the 6100a files on n1 
+-- was auto replicated to n2.
+-- In the end, the same objects are dropped.
+
+-- Prepared statement for spock.tables so that we can execute it frequently in the script below
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname = $1 ORDER BY relid;
+
+-- Final validation of all tables along with querying the spock.tables
+\d+ employees
+EXECUTE spocktab('employees');
+
+\d+ departments
+execute spocktab('departments');
+
+\d+ projects
+execute spocktab('projects');
+
+\d+ employee_projects
+execute spocktab('employee_projects');
+
+\d+ products
+execute spocktab('products');
+
+\d+ "CaseSensitiveTable"
+execute spocktab('CaseSensitiveTable');
+
+\d+ test_tab1
+execute spocktab('test_tab1');
+
+\d+ test_tab2
+execute spocktab('test_tab2');
+
+\d+ test_tab3
+execute spocktab('test_tab3');
+
+\d+ test_tab4
+EXECUTE spocktab('test_tab4');
+
+-- Validating data in all tables
+SELECT * FROM employees ORDER BY emp_id;
+SELECT * FROM departments ORDER BY dept_id;
+SELECT * FROM projects ORDER BY project_id;
+SELECT * FROM employee_projects ORDER BY emp_id, project_id;
+SELECT * FROM products ORDER BY product_id;
+SELECT * FROM "CaseSensitiveTable" ORDER BY "ID";
+SELECT * FROM test_tab1 ORDER BY id;
+SELECT * FROM test_tab2 ORDER BY id;
+SELECT * FROM test_tab3 ORDER BY id;
+SELECT * FROM test_tab4 ORDER BY id;
+
+-- Execute drop statements on n2 to exercise DROP TABLE, ensuring it gets replicated.
+-- This also helps with the cleanup
+drop table employees cascade;
+drop table departments cascade;
+drop table projects cascade;
+drop table employee_projects cascade;
+drop table products cascade;
+drop table "CaseSensitiveTable";
+drop table test_tab1;
+drop table test_tab2;
+drop table test_tab3;
+drop table test_tab4;

--- a/test/t/auto_ddl/6100c_table_validate_n1.out
+++ b/test/t/auto_ddl/6100c_table_validate_n1.out
@@ -1,0 +1,78 @@
+-- Final AutoDDL validation for the 6100 series on n1 to ensure all the DROP TABLE performed in the 6100b files on n2 
+-- was auto replicated to n1.
+-- None of the Tables should exist and spock.tables should not contain any entries for these tables
+-- Prepared statement for spock.tables so that we can execute it frequently in the script below
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname = $1 ORDER BY relid;
+PREPARE
+-- Final validation of all tables along with querying the spock.tables
+-- validating all tables dropped on n1
+\d+ employees
+Did not find any relation named "employees".
+EXECUTE spocktab('employees');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+\d+ departments
+Did not find any relation named "departments".
+execute spocktab('departments');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+\d+ projects
+Did not find any relation named "projects".
+execute spocktab('projects');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+\d+ employee_projects
+Did not find any relation named "employee_projects".
+execute spocktab('employee_projects');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+\d+ products
+Did not find any relation named "products".
+execute spocktab('products');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+\d+ "CaseSensitiveTable"
+Did not find any relation named ""CaseSensitiveTable"".
+execute spocktab('CaseSensitiveTable');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+\d+ test_tab1
+Did not find any relation named "test_tab1".
+execute spocktab('test_tab1');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+\d+ test_tab2
+Did not find any relation named "test_tab2".
+execute spocktab('test_tab2');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+\d+ test_tab3
+Did not find any relation named "test_tab3".
+execute spocktab('test_tab3');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+\d+ test_tab4
+Did not find any relation named "test_tab4".
+EXECUTE spocktab('test_tab4');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+

--- a/test/t/auto_ddl/6100c_table_validate_n1.sql
+++ b/test/t/auto_ddl/6100c_table_validate_n1.sql
@@ -1,0 +1,39 @@
+
+-- Final AutoDDL validation for the 6100 series on n1 to ensure all the DROP TABLE performed in the 6100b files on n2 
+-- was auto replicated to n1.
+-- None of the Tables should exist and spock.tables should not contain any entries for these tables
+
+-- Prepared statement for spock.tables so that we can execute it frequently in the script below
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname = $1 ORDER BY relid;
+
+-- Final validation of all tables along with querying the spock.tables
+-- validating all tables dropped on n1
+\d+ employees
+EXECUTE spocktab('employees');
+
+\d+ departments
+execute spocktab('departments');
+
+\d+ projects
+execute spocktab('projects');
+
+\d+ employee_projects
+execute spocktab('employee_projects');
+
+\d+ products
+execute spocktab('products');
+
+\d+ "CaseSensitiveTable"
+execute spocktab('CaseSensitiveTable');
+
+\d+ test_tab1
+execute spocktab('test_tab1');
+
+\d+ test_tab2
+execute spocktab('test_tab2');
+
+\d+ test_tab3
+execute spocktab('test_tab3');
+
+\d+ test_tab4
+EXECUTE spocktab('test_tab4');

--- a/test/t/auto_ddl/6111a_table_tx_ctas_selectinto_like.out
+++ b/test/t/auto_ddl/6111a_table_tx_ctas_selectinto_like.out
@@ -1,0 +1,711 @@
+-- This script covers the following CREATE TABLE constructs for AutoDDL:
+-- CREATE TABLE in transactions
+-- CREATE TABLE AS
+-- SELECT .. INTO .. FROM EXISTING
+-- CREATE TABLE LIKE
+-- Prepared statement for spock.tables so that we can execute it frequently in the script below
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname = $1 ORDER BY relid;
+PREPARE
+----------------------------
+-- Table DDL in transactions
+----------------------------
+-- Create Table within transaction, commit
+--table should be created successfully (and auto replicated)
+BEGIN;
+BEGIN
+CREATE TABLE sub_tx_table0 (c int primary key);
+INFO:  DDL statement replicated.
+CREATE TABLE
+COMMIT;
+COMMIT
+\d sub_tx_table0
+           Table "public.sub_tx_table0"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ c      | integer |           | not null | 
+Indexes:
+    "sub_tx_table0_pkey" PRIMARY KEY, btree (c)
+
+EXECUTE spocktab('sub_tx_table0'); --default repset
+ nspname |    relname    | set_name 
+---------+---------------+----------
+ public  | sub_tx_table0 | default
+(1 row)
+
+-- DDL within tx, Rollback
+-- table will not get created on n1 and therefore nothing should replicate to n2
+-- (although the ddl replication INFO message would appear but it should rollback)
+BEGIN;
+BEGIN
+CREATE TABLE sub_tx_table0a (c int);
+INFO:  DDL statement replicated.
+CREATE TABLE
+ROLLBACK;
+ROLLBACK
+\d sub_tx_table0a
+Did not find any relation named "sub_tx_table0a".
+EXECUTE spocktab('sub_tx_table0a');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+--DDL within transaction and savepoints and rollback/commit
+--table sub_tx_table1 will not be created so it should not get replicated
+BEGIN;
+BEGIN
+SAVEPOINT a;
+SAVEPOINT
+CREATE TABLE sub_tx_table1 (c int);
+INFO:  DDL statement replicated.
+CREATE TABLE
+ ALTER TABLE sub_tx_table1 ALTER c TYPE bigint; 
+INFO:  DDL statement replicated.
+ALTER TABLE
+ ROLLBACK TO a;
+ROLLBACK
+COMMIT;
+COMMIT
+\d sub_tx_table1
+Did not find any relation named "sub_tx_table1".
+EXECUTE spocktab('sub_tx_table1');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+--ALTERING TABLE within transaction, savepoints, rollback
+-- After commit, the table should have c column datatype to bigint
+CREATE TABLE sub_tx_table2 (c int);
+INFO:  DDL statement replicated.
+CREATE TABLE
+BEGIN;
+BEGIN
+  ALTER TABLE sub_tx_table2 ALTER c TYPE bigint;
+INFO:  DDL statement replicated.
+ALTER TABLE
+  SAVEPOINT q; 
+SAVEPOINT
+  DROP TABLE sub_tx_table2; 
+NOTICE:  drop cascades to table sub_tx_table2 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+  ROLLBACK TO q;
+ROLLBACK
+COMMIT;
+COMMIT
+\d sub_tx_table2
+           Table "public.sub_tx_table2"
+ Column |  Type  | Collation | Nullable | Default 
+--------+--------+-----------+----------+---------
+ c      | bigint |           |          | 
+
+EXECUTE spocktab('sub_tx_table2');
+ nspname |    relname    |      set_name       
+---------+---------------+---------------------
+ public  | sub_tx_table2 | default_insert_only
+(1 row)
+
+BEGIN;
+BEGIN
+CREATE TABLE sub_tx_table3 (a smallint primary key, b real);
+INFO:  DDL statement replicated.
+CREATE TABLE
+INSERT INTO sub_tx_table3 VALUES
+  (56, 7.8), (100, 99.097), (0, 0.09561), (42, 324.78), (777, 777.777);
+INSERT 0 5
+END;
+COMMIT
+\d sub_tx_table3
+            Table "public.sub_tx_table3"
+ Column |   Type   | Collation | Nullable | Default 
+--------+----------+-----------+----------+---------
+ a      | smallint |           | not null | 
+ b      | real     |           |          | 
+Indexes:
+    "sub_tx_table3_pkey" PRIMARY KEY, btree (a)
+
+SELECT * FROM sub_tx_table3 order by a;
+  a  |    b    
+-----+---------
+   0 | 0.09561
+  42 |  324.78
+  56 |     7.8
+ 100 |  99.097
+ 777 | 777.777
+(5 rows)
+
+EXECUTE spocktab('sub_tx_table3');
+ nspname |    relname    | set_name 
+---------+---------------+----------
+ public  | sub_tx_table3 | default
+(1 row)
+
+BEGIN;
+BEGIN
+CREATE TABLE sub_tx_table4 (a int4 primary key);
+INFO:  DDL statement replicated.
+CREATE TABLE
+DELETE FROM sub_tx_table3;
+DELETE 5
+-- should be empty
+SELECT count(*) from sub_tx_table3;--0 rows
+ count 
+-------
+     0
+(1 row)
+
+ABORT;--rollback
+ROLLBACK
+--table sub_tx_table4 should not exist
+\d sub_tx_table4
+Did not find any relation named "sub_tx_table4".
+EXECUTE spocktab('sub_tx_table4');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+SELECT count(*) from sub_tx_table3;--5 rows, which should also exist on n2 (validated in the 6111b file)
+ count 
+-------
+     5
+(1 row)
+
+-- Nested transactions with multiple savepoints and a mix of rollbacks and commits
+BEGIN;
+BEGIN
+  CREATE TABLE sub_tx_table5 (c int);
+INFO:  DDL statement replicated.
+CREATE TABLE
+  SAVEPOINT sp3;
+SAVEPOINT
+  CREATE TABLE sub_tx_table5a (c int primary key);
+INFO:  DDL statement replicated.
+CREATE TABLE
+  SAVEPOINT sp4;
+SAVEPOINT
+  CREATE TABLE sub_tx_table5b (c int);
+INFO:  DDL statement replicated.
+CREATE TABLE
+  ROLLBACK TO sp4; -- Rolls back the creation of sub_tx_table5b
+ROLLBACK
+  SAVEPOINT sp5;
+SAVEPOINT
+  CREATE TABLE sub_tx_table5c (c int);
+INFO:  DDL statement replicated.
+CREATE TABLE
+  COMMIT; -- Commits all changes since the last rollback, sub_tx_table5a and sub_tx_table5c should exist
+COMMIT
+COMMIT;
+WARNING:  there is no transaction in progress
+COMMIT
+-- Validate sub_tx_table5, sub_tx_table5a, and sub_tx_table5c should exist, sub_tx_table5b should not
+\d sub_tx_table5
+           Table "public.sub_tx_table5"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ c      | integer |           |          | 
+
+EXECUTE spocktab('sub_tx_table5'); -- should be in default_insert_only set
+ nspname |    relname    |      set_name       
+---------+---------------+---------------------
+ public  | sub_tx_table5 | default_insert_only
+(1 row)
+
+\d sub_tx_table5a
+           Table "public.sub_tx_table5a"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ c      | integer |           | not null | 
+Indexes:
+    "sub_tx_table5a_pkey" PRIMARY KEY, btree (c)
+
+EXECUTE spocktab('sub_tx_table5a'); -- should be in default
+ nspname |    relname     | set_name 
+---------+----------------+----------
+ public  | sub_tx_table5a | default
+(1 row)
+
+\d sub_tx_table5b
+Did not find any relation named "sub_tx_table5b".
+EXECUTE spocktab('sub_tx_table5b'); -- should not exist
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+\d sub_tx_table5c
+           Table "public.sub_tx_table5c"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ c      | integer |           |          | 
+
+EXECUTE spocktab('sub_tx_table5c'); -- should be in default_insert_only set
+ nspname |    relname     |      set_name       
+---------+----------------+---------------------
+ public  | sub_tx_table5c | default_insert_only
+(1 row)
+
+-----------------------
+-- CREATE TABLE AS
+-----------------------
+-- Create a base table for reference
+CREATE TABLE table_base1 (
+    id INT PRIMARY KEY,
+    name VARCHAR(50),
+    age INT
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into table_base1
+INSERT INTO table_base1 (id, name, age) VALUES
+(1, 'Alice', 30),
+(2, 'Bob', 25),
+(3, 'Carol', 35);
+INSERT 0 3
+-- Basic CREATE TABLE AS with data
+CREATE TABLE table_ctas1 AS
+SELECT * FROM table_base1;
+WARNING:  DDL statement replicated, but could be unsafe.
+SELECT 3
+-- CREATE TABLE AS with IF NOT EXISTS
+CREATE TABLE IF NOT EXISTS table_ctas1 AS
+SELECT id, name FROM table_base1;
+NOTICE:  relation "table_ctas1" already exists, skipping
+WARNING:  DDL statement replicated, but could be unsafe.
+CREATE TABLE AS
+-- Validate table_ctas1
+\d table_ctas1
+                   Table "public.table_ctas1"
+ Column |         Type          | Collation | Nullable | Default 
+--------+-----------------------+-----------+----------+---------
+ id     | integer               |           |          | 
+ name   | character varying(50) |           |          | 
+ age    | integer               |           |          | 
+
+EXECUTE spocktab('table_ctas1'); -- should be in default_insert_only set
+ nspname |   relname   |      set_name       
+---------+-------------+---------------------
+ public  | table_ctas1 | default_insert_only
+(1 row)
+
+-- CREATE TABLE AS with specific columns and data
+CREATE TABLE IF NOT EXISTS table_ctas2 AS
+SELECT id, age FROM table_base1
+WHERE age > 30;
+WARNING:  DDL statement replicated, but could be unsafe.
+SELECT 1
+-- Add primary key through ALTER TABLE
+ALTER TABLE table_ctas2 ADD PRIMARY KEY (id);
+INFO:  DDL statement replicated.
+ALTER TABLE
+-- Validate table_ctas2
+\d table_ctas2
+            Table "public.table_ctas2"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ id     | integer |           | not null | 
+ age    | integer |           |          | 
+Indexes:
+    "table_ctas2_pkey" PRIMARY KEY, btree (id)
+
+EXECUTE spocktab('table_ctas2'); -- should be in default set
+ nspname |   relname   | set_name 
+---------+-------------+----------
+ public  | table_ctas2 | default
+(1 row)
+
+-- CREATE TABLE AS with VALUES clause and primary key
+CREATE TABLE table_ctas3 (id, value) AS
+VALUES (1, 10), (2, 20), (3, 30);
+WARNING:  DDL statement replicated, but could be unsafe.
+SELECT 3
+ALTER TABLE table_ctas3 ADD PRIMARY KEY (id);
+INFO:  DDL statement replicated.
+ALTER TABLE
+-- Validate table_ctas3
+\d table_ctas3
+            Table "public.table_ctas3"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ id     | integer |           | not null | 
+ value  | integer |           |          | 
+Indexes:
+    "table_ctas3_pkey" PRIMARY KEY, btree (id)
+
+EXECUTE spocktab('table_ctas3'); -- should be in default set
+ nspname |   relname   | set_name 
+---------+-------------+----------
+ public  | table_ctas3 | default
+(1 row)
+
+-- CREATE TABLE AS with query and using WITH NO DATA
+CREATE TABLE table_ctas4 AS
+SELECT id, name, age * 2 AS double_age FROM table_base1
+WHERE age <= 30 WITH NO DATA;
+WARNING:  DDL statement replicated, but could be unsafe.
+CREATE TABLE AS
+-- Validate table_ctas4
+\d table_ctas4
+                     Table "public.table_ctas4"
+   Column   |         Type          | Collation | Nullable | Default 
+------------+-----------------------+-----------+----------+---------
+ id         | integer               |           |          | 
+ name       | character varying(50) |           |          | 
+ double_age | integer               |           |          | 
+
+EXECUTE spocktab('table_ctas4'); -- should be in default_insert_only set
+ nspname |   relname   |      set_name       
+---------+-------------+---------------------
+ public  | table_ctas4 | default_insert_only
+(1 row)
+
+-- CREATE TABLE AS with expression 
+CREATE TABLE table_ctas5 AS
+SELECT generate_series(1, 10) AS num;
+WARNING:  DDL statement replicated, but could be unsafe.
+SELECT 10
+-- Validate table_ctas5
+\d table_ctas5
+            Table "public.table_ctas5"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ num    | integer |           |          | 
+
+EXECUTE spocktab('table_ctas5'); -- should be in default_insert_only set
+ nspname |   relname   |      set_name       
+---------+-------------+---------------------
+ public  | table_ctas5 | default_insert_only
+(1 row)
+
+-- CREATE TABLE AS with explain analyze, redirecting the output to /dev/null so that the varying query plan is not 
+-- captured in the expected output, to keep our output consistent across runs.
+\o /dev/null
+EXPLAIN ANALYZE CREATE TABLE table_ctas6 AS
+SELECT 1 AS a;
+INFO:  DDL statement replicated.
+\o
+-- Validate table_ctas6
+\d table_ctas6
+            Table "public.table_ctas6"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ a      | integer |           |          | 
+
+EXECUTE spocktab('table_ctas6'); -- should be in default_insert_only set
+ nspname |   relname   | set_name 
+---------+-------------+----------
+ public  | table_ctas6 | 
+(1 row)
+
+-----------------------------------
+-- Create table using SELECT .. INTO .. 
+-----------------------------------
+-- Create an existing table for reference
+CREATE TABLE table_existing1 (
+    id INT PRIMARY KEY,
+    column1 TEXT,
+    column2 INT,
+    column3 DATE,
+    column4 BOOLEAN
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into table_existing1
+INSERT INTO table_existing1 (id, column1, column2, column3, column4) VALUES
+(1, 'value1', 10, '2023-01-01', TRUE),
+(2, 'value2', 20, '2023-01-02', FALSE),
+(3, 'value3', 30, '2023-01-03', TRUE),
+(4, 'value4', 40, '2023-01-04', FALSE);
+INSERT 0 4
+-- Basic SELECT INTO
+SELECT * INTO table_si1 FROM table_existing1;
+WARNING:  DDL statement replicated, but could be unsafe.
+SELECT 4
+-- Validate table_si1
+\d table_si1
+              Table "public.table_si1"
+ Column  |  Type   | Collation | Nullable | Default 
+---------+---------+-----------+----------+---------
+ id      | integer |           |          | 
+ column1 | text    |           |          | 
+ column2 | integer |           |          | 
+ column3 | date    |           |          | 
+ column4 | boolean |           |          | 
+
+EXECUTE spocktab('table_si1'); -- should be in default_insert_only set
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | table_si1 | default_insert_only
+(1 row)
+
+-- SELECT INTO with specific columns and conditions
+SELECT id, column1, column2 INTO table_si2 FROM table_existing1 WHERE column2 > 20;
+WARNING:  DDL statement replicated, but could be unsafe.
+SELECT 2
+-- Validate table_si2
+\d table_si2
+              Table "public.table_si2"
+ Column  |  Type   | Collation | Nullable | Default 
+---------+---------+-----------+----------+---------
+ id      | integer |           |          | 
+ column1 | text    |           |          | 
+ column2 | integer |           |          | 
+
+EXECUTE spocktab('table_si2'); -- should be in default_insert_only set
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | table_si2 | default_insert_only
+(1 row)
+
+-- Expected data: (3, 'value3', 30), (4, 'value4', 40)
+-- SELECT INTO with GROUP BY and HAVING
+SELECT column4, COUNT(*) AS count INTO table_si3 FROM table_existing1 GROUP BY column4 HAVING COUNT(*) > 1;
+WARNING:  DDL statement replicated, but could be unsafe.
+SELECT 2
+-- Validate table_si3
+\d table_si3
+              Table "public.table_si3"
+ Column  |  Type   | Collation | Nullable | Default 
+---------+---------+-----------+----------+---------
+ column4 | boolean |           |          | 
+ count   | bigint  |           |          | 
+
+EXECUTE spocktab('table_si3'); -- should be in default_insert_only set
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | table_si3 | default_insert_only
+(1 row)
+
+-- Expected data: (TRUE, 2), (FALSE, 2)
+-- SELECT INTO with ORDER BY and LIMIT
+SELECT id, column1 INTO table_si4 FROM table_existing1 ORDER BY column2 DESC LIMIT 2;
+WARNING:  DDL statement replicated, but could be unsafe.
+SELECT 2
+-- Validate table_si4
+\d table_si4
+              Table "public.table_si4"
+ Column  |  Type   | Collation | Nullable | Default 
+---------+---------+-----------+----------+---------
+ id      | integer |           |          | 
+ column1 | text    |           |          | 
+
+EXECUTE spocktab('table_si4'); -- should be in default_insert_only set
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | table_si4 | default_insert_only
+(1 row)
+
+-- Expected data: (4, 'value4'), (3, 'value3')
+-- Complex SELECT INTO with JOIN, GROUP BY, ORDER BY, and LIMIT
+CREATE TABLE table_existing2 (
+    ref_id INT,
+    extra_data VARCHAR(50)
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into table_existing2
+INSERT INTO table_existing2 (ref_id, extra_data) VALUES
+(1, 'extra1'),
+(2, 'extra2'),
+(3, 'extra3'),
+(4, 'extra4');
+INSERT 0 4
+SELECT e1.id, e1.column1, e2.extra_data INTO table_si5
+FROM table_existing1 e1
+JOIN table_existing2 e2 ON e1.id = e2.ref_id
+WHERE e1.column4 = TRUE
+GROUP BY e1.id, e1.column1, e2.extra_data
+ORDER BY e1.id
+LIMIT 3;
+WARNING:  DDL statement replicated, but could be unsafe.
+SELECT 2
+-- Validate table_si5
+\d table_si5
+                      Table "public.table_si5"
+   Column   |         Type          | Collation | Nullable | Default 
+------------+-----------------------+-----------+----------+---------
+ id         | integer               |           |          | 
+ column1    | text                  |           |          | 
+ extra_data | character varying(50) |           |          | 
+
+EXECUTE spocktab('table_si5'); -- should be in default_insert_only set
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | table_si5 | default_insert_only
+(1 row)
+
+-- Expected data: (1, 'value1', 'extra1'), (3, 'value3', 'extra3')
+---------------------
+-- Create table using CREATE TABLE LIKE
+--------------------
+-- Create base tables with various constraints
+-- Base table with primary key and default value
+CREATE TABLE table_base1a (
+    col1 INT PRIMARY KEY,
+    col2 TEXT DEFAULT 'default_text'
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Base table without primary key, but with check constraint and unique constraint
+CREATE TABLE table_base2 (
+    col1 INT,
+    col2 TEXT,
+    col3 DATE,
+    CONSTRAINT chk_col1 CHECK (col1 > 0),
+    UNIQUE (col2)
+);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Insert initial data into table_base1a
+INSERT INTO table_base1a (col1, col2) VALUES (1, 'text1'), (2, 'text2');
+INSERT 0 2
+-- Insert initial data into table_base2
+INSERT INTO table_base2 (col1, col2, col3) VALUES (1, 'unique_text1', '2023-01-01'), (2, 'unique_text2', '2023-01-02');
+INSERT 0 2
+-- Create table using LIKE including defaults and constraints
+CREATE TABLE table_l1 (LIKE table_base1a INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Validate table_l1
+-- Expected columns: col1 (without primary key), col2 (with default 'default_text')
+\d table_l1
+                    Table "public.table_l1"
+ Column |  Type   | Collation | Nullable |       Default        
+--------+---------+-----------+----------+----------------------
+ col1   | integer |           | not null | 
+ col2   | text    |           |          | 'default_text'::text
+
+EXECUTE spocktab('table_l1'); -- should be in default_insert_only set
+ nspname | relname  |      set_name       
+---------+----------+---------------------
+ public  | table_l1 | default_insert_only
+(1 row)
+
+-- Create table using LIKE excluding defaults
+CREATE TABLE table_l2 (LIKE table_base1a EXCLUDING DEFAULTS);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Validate table_l2
+-- Expected columns: col1 (without primary key), col2 (without default)
+\d table_l2
+              Table "public.table_l2"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ col1   | integer |           | not null | 
+ col2   | text    |           |          | 
+
+EXECUTE spocktab('table_l2'); -- should be in default_insert_only set
+ nspname | relname  |      set_name       
+---------+----------+---------------------
+ public  | table_l2 | default_insert_only
+(1 row)
+
+-- Create table using LIKE including all properties
+CREATE TABLE table_l3 (LIKE table_base2 INCLUDING ALL);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Validate table_l3
+-- Expected columns: col1, col2, col3 (with check constraint and unique constraint)
+\d table_l3
+              Table "public.table_l3"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ col1   | integer |           |          | 
+ col2   | text    |           |          | 
+ col3   | date    |           |          | 
+Indexes:
+    "table_l3_col2_key" UNIQUE CONSTRAINT, btree (col2)
+Check constraints:
+    "chk_col1" CHECK (col1 > 0)
+
+EXECUTE spocktab('table_l3'); -- should be in default_insert_only set
+ nspname | relname  |      set_name       
+---------+----------+---------------------
+ public  | table_l3 | default_insert_only
+(1 row)
+
+-- Create table using LIKE excluding constraints
+CREATE TABLE table_l4 (LIKE table_base2 EXCLUDING CONSTRAINTS);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Validate table_l4
+-- Expected columns: col1, col2, col3 (without constraints)
+\d table_l4
+              Table "public.table_l4"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ col1   | integer |           |          | 
+ col2   | text    |           |          | 
+ col3   | date    |           |          | 
+
+EXECUTE spocktab('table_l4'); -- should be in default_insert_only set
+ nspname | relname  |      set_name       
+---------+----------+---------------------
+ public  | table_l4 | default_insert_only
+(1 row)
+
+-- Create table using LIKE including indexes
+CREATE TABLE table_l5 (LIKE table_base1a INCLUDING INDEXES);
+INFO:  DDL statement replicated.
+CREATE TABLE
+-- Validate table_l5
+-- Expected columns: col1 (primary key), col2 (without default), indexes copied
+\d table_l5
+              Table "public.table_l5"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ col1   | integer |           | not null | 
+ col2   | text    |           |          | 
+Indexes:
+    "table_l5_pkey" PRIMARY KEY, btree (col1)
+
+EXECUTE spocktab('table_l5'); -- should be in default set
+ nspname | relname  | set_name 
+---------+----------+----------
+ public  | table_l5 | default
+(1 row)
+
+-- Insert data into the LIKE created tables to validate defaults and constraints
+INSERT INTO table_l1 (col1) VALUES (3);
+INSERT 0 1
+INSERT INTO table_l2 (col1, col2) VALUES (4, 'text4');
+INSERT 0 1
+INSERT INTO table_l3 (col1, col2, col3) VALUES (3, 'unique_text3', '2023-01-03');
+INSERT 0 1
+INSERT INTO table_l4 (col1, col2, col3) VALUES (4, 'text4', '2023-01-04');
+INSERT 0 1
+INSERT INTO table_l5 (col1) VALUES (5);
+INSERT 0 1
+-- Validate data in table_l1 , Expected data: (3, 'default_text')
+SELECT * FROM table_l1;
+ col1 |     col2     
+------+--------------
+    3 | default_text
+(1 row)
+
+-- Validate data in table_l2 , Expected data: (4, 'text4')
+SELECT * FROM table_l2;
+ col1 | col2  
+------+-------
+    4 | text4
+(1 row)
+
+-- Validate data in table_l3 , Expected data: (3, 'unique_text3', '2023-01-03')
+SELECT * FROM table_l3;
+ col1 |     col2     |    col3    
+------+--------------+------------
+    3 | unique_text3 | 2023-01-03
+(1 row)
+
+-- Validate data in table_l4 ,  Expected data: (4, 'text4', '2023-01-04')
+SELECT * FROM table_l4;
+ col1 | col2  |    col3    
+------+-------+------------
+    4 | text4 | 2023-01-04
+(1 row)
+
+-- Validate data in table_l5, Expected data: (5, )
+SELECT * FROM table_l5;
+ col1 | col2 
+------+------
+    5 | 
+(1 row)
+

--- a/test/t/auto_ddl/6111a_table_tx_ctas_selectinto_like.sql
+++ b/test/t/auto_ddl/6111a_table_tx_ctas_selectinto_like.sql
@@ -1,0 +1,350 @@
+-- This script covers the following CREATE TABLE constructs for AutoDDL:
+-- CREATE TABLE in transactions
+-- CREATE TABLE AS
+-- SELECT .. INTO .. FROM EXISTING
+-- CREATE TABLE LIKE
+
+
+-- Prepared statement for spock.tables so that we can execute it frequently in the script below
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname = $1 ORDER BY relid;
+
+----------------------------
+-- Table DDL in transactions
+----------------------------
+
+-- Create Table within transaction, commit
+--table should be created successfully (and auto replicated)
+BEGIN;
+CREATE TABLE sub_tx_table0 (c int primary key);
+COMMIT;
+
+\d sub_tx_table0
+EXECUTE spocktab('sub_tx_table0'); --default repset
+
+-- DDL within tx, Rollback
+-- table will not get created on n1 and therefore nothing should replicate to n2
+-- (although the ddl replication INFO message would appear but it should rollback)
+BEGIN;
+CREATE TABLE sub_tx_table0a (c int);
+ROLLBACK;
+
+\d sub_tx_table0a
+EXECUTE spocktab('sub_tx_table0a');
+
+--DDL within transaction and savepoints and rollback/commit
+--table sub_tx_table1 will not be created so it should not get replicated
+BEGIN;
+SAVEPOINT a;
+CREATE TABLE sub_tx_table1 (c int);
+ ALTER TABLE sub_tx_table1 ALTER c TYPE bigint; 
+ ROLLBACK TO a;
+COMMIT;
+
+\d sub_tx_table1
+EXECUTE spocktab('sub_tx_table1');
+
+--ALTERING TABLE within transaction, savepoints, rollback
+-- After commit, the table should have c column datatype to bigint
+CREATE TABLE sub_tx_table2 (c int);
+BEGIN;
+  ALTER TABLE sub_tx_table2 ALTER c TYPE bigint;
+  SAVEPOINT q; 
+  DROP TABLE sub_tx_table2; 
+  ROLLBACK TO q;
+COMMIT;
+
+\d sub_tx_table2
+EXECUTE spocktab('sub_tx_table2');
+
+BEGIN;
+CREATE TABLE sub_tx_table3 (a smallint primary key, b real);
+INSERT INTO sub_tx_table3 VALUES
+  (56, 7.8), (100, 99.097), (0, 0.09561), (42, 324.78), (777, 777.777);
+END;
+
+\d sub_tx_table3
+SELECT * FROM sub_tx_table3 order by a;
+EXECUTE spocktab('sub_tx_table3');
+
+BEGIN;
+CREATE TABLE sub_tx_table4 (a int4 primary key);
+DELETE FROM sub_tx_table3;
+-- should be empty
+SELECT count(*) from sub_tx_table3;--0 rows
+ABORT;--rollback
+--table sub_tx_table4 should not exist
+\d sub_tx_table4
+EXECUTE spocktab('sub_tx_table4');
+SELECT count(*) from sub_tx_table3;--5 rows, which should also exist on n2 (validated in the 6111b file)
+
+-- Nested transactions with multiple savepoints and a mix of rollbacks and commits
+BEGIN;
+  CREATE TABLE sub_tx_table5 (c int);
+  SAVEPOINT sp3;
+  CREATE TABLE sub_tx_table5a (c int primary key);
+  SAVEPOINT sp4;
+  CREATE TABLE sub_tx_table5b (c int);
+  ROLLBACK TO sp4; -- Rolls back the creation of sub_tx_table5b
+  SAVEPOINT sp5;
+  CREATE TABLE sub_tx_table5c (c int);
+  COMMIT; -- Commits all changes since the last rollback, sub_tx_table5a and sub_tx_table5c should exist
+COMMIT;
+
+-- Validate sub_tx_table5, sub_tx_table5a, and sub_tx_table5c should exist, sub_tx_table5b should not
+\d sub_tx_table5
+EXECUTE spocktab('sub_tx_table5'); -- should be in default_insert_only set
+\d sub_tx_table5a
+EXECUTE spocktab('sub_tx_table5a'); -- should be in default
+\d sub_tx_table5b
+EXECUTE spocktab('sub_tx_table5b'); -- should not exist
+\d sub_tx_table5c
+EXECUTE spocktab('sub_tx_table5c'); -- should be in default_insert_only set
+
+
+
+-----------------------
+-- CREATE TABLE AS
+-----------------------
+
+-- Create a base table for reference
+CREATE TABLE table_base1 (
+    id INT PRIMARY KEY,
+    name VARCHAR(50),
+    age INT
+);
+
+-- Insert initial data into table_base1
+INSERT INTO table_base1 (id, name, age) VALUES
+(1, 'Alice', 30),
+(2, 'Bob', 25),
+(3, 'Carol', 35);
+
+-- Basic CREATE TABLE AS with data
+CREATE TABLE table_ctas1 AS
+SELECT * FROM table_base1;
+
+-- CREATE TABLE AS with IF NOT EXISTS
+CREATE TABLE IF NOT EXISTS table_ctas1 AS
+SELECT id, name FROM table_base1;
+
+-- Validate table_ctas1
+\d table_ctas1
+EXECUTE spocktab('table_ctas1'); -- should be in default_insert_only set
+
+-- CREATE TABLE AS with specific columns and data
+CREATE TABLE IF NOT EXISTS table_ctas2 AS
+SELECT id, age FROM table_base1
+WHERE age > 30;
+
+-- Add primary key through ALTER TABLE
+ALTER TABLE table_ctas2 ADD PRIMARY KEY (id);
+
+-- Validate table_ctas2
+\d table_ctas2
+EXECUTE spocktab('table_ctas2'); -- should be in default set
+
+-- CREATE TABLE AS with VALUES clause and primary key
+CREATE TABLE table_ctas3 (id, value) AS
+VALUES (1, 10), (2, 20), (3, 30);
+ALTER TABLE table_ctas3 ADD PRIMARY KEY (id);
+
+-- Validate table_ctas3
+\d table_ctas3
+EXECUTE spocktab('table_ctas3'); -- should be in default set
+
+-- CREATE TABLE AS with query and using WITH NO DATA
+CREATE TABLE table_ctas4 AS
+SELECT id, name, age * 2 AS double_age FROM table_base1
+WHERE age <= 30 WITH NO DATA;
+
+-- Validate table_ctas4
+\d table_ctas4
+EXECUTE spocktab('table_ctas4'); -- should be in default_insert_only set
+
+-- CREATE TABLE AS with expression 
+CREATE TABLE table_ctas5 AS
+SELECT generate_series(1, 10) AS num;
+
+-- Validate table_ctas5
+\d table_ctas5
+EXECUTE spocktab('table_ctas5'); -- should be in default_insert_only set
+
+-- CREATE TABLE AS with explain analyze, redirecting the output to /dev/null so that the varying query plan is not 
+-- captured in the expected output, to keep our output consistent across runs.
+\o /dev/null
+EXPLAIN ANALYZE CREATE TABLE table_ctas6 AS
+SELECT 1 AS a;
+\o
+
+-- Validate table_ctas6
+\d table_ctas6
+EXECUTE spocktab('table_ctas6'); -- should be in default_insert_only set
+
+-----------------------------------
+-- Create table using SELECT .. INTO .. 
+-----------------------------------
+
+-- Create an existing table for reference
+CREATE TABLE table_existing1 (
+    id INT PRIMARY KEY,
+    column1 TEXT,
+    column2 INT,
+    column3 DATE,
+    column4 BOOLEAN
+);
+
+-- Insert initial data into table_existing1
+INSERT INTO table_existing1 (id, column1, column2, column3, column4) VALUES
+(1, 'value1', 10, '2023-01-01', TRUE),
+(2, 'value2', 20, '2023-01-02', FALSE),
+(3, 'value3', 30, '2023-01-03', TRUE),
+(4, 'value4', 40, '2023-01-04', FALSE);
+
+-- Basic SELECT INTO
+SELECT * INTO table_si1 FROM table_existing1;
+
+-- Validate table_si1
+\d table_si1
+EXECUTE spocktab('table_si1'); -- should be in default_insert_only set
+
+-- SELECT INTO with specific columns and conditions
+SELECT id, column1, column2 INTO table_si2 FROM table_existing1 WHERE column2 > 20;
+
+-- Validate table_si2
+\d table_si2
+EXECUTE spocktab('table_si2'); -- should be in default_insert_only set
+-- Expected data: (3, 'value3', 30), (4, 'value4', 40)
+
+-- SELECT INTO with GROUP BY and HAVING
+SELECT column4, COUNT(*) AS count INTO table_si3 FROM table_existing1 GROUP BY column4 HAVING COUNT(*) > 1;
+
+-- Validate table_si3
+\d table_si3
+EXECUTE spocktab('table_si3'); -- should be in default_insert_only set
+-- Expected data: (TRUE, 2), (FALSE, 2)
+
+-- SELECT INTO with ORDER BY and LIMIT
+SELECT id, column1 INTO table_si4 FROM table_existing1 ORDER BY column2 DESC LIMIT 2;
+
+-- Validate table_si4
+\d table_si4
+EXECUTE spocktab('table_si4'); -- should be in default_insert_only set
+-- Expected data: (4, 'value4'), (3, 'value3')
+
+-- Complex SELECT INTO with JOIN, GROUP BY, ORDER BY, and LIMIT
+CREATE TABLE table_existing2 (
+    ref_id INT,
+    extra_data VARCHAR(50)
+);
+
+-- Insert initial data into table_existing2
+INSERT INTO table_existing2 (ref_id, extra_data) VALUES
+(1, 'extra1'),
+(2, 'extra2'),
+(3, 'extra3'),
+(4, 'extra4');
+
+SELECT e1.id, e1.column1, e2.extra_data INTO table_si5
+FROM table_existing1 e1
+JOIN table_existing2 e2 ON e1.id = e2.ref_id
+WHERE e1.column4 = TRUE
+GROUP BY e1.id, e1.column1, e2.extra_data
+ORDER BY e1.id
+LIMIT 3;
+
+-- Validate table_si5
+\d table_si5
+EXECUTE spocktab('table_si5'); -- should be in default_insert_only set
+-- Expected data: (1, 'value1', 'extra1'), (3, 'value3', 'extra3')
+
+---------------------
+-- Create table using CREATE TABLE LIKE
+--------------------
+
+-- Create base tables with various constraints
+
+-- Base table with primary key and default value
+CREATE TABLE table_base1a (
+    col1 INT PRIMARY KEY,
+    col2 TEXT DEFAULT 'default_text'
+);
+
+-- Base table without primary key, but with check constraint and unique constraint
+CREATE TABLE table_base2 (
+    col1 INT,
+    col2 TEXT,
+    col3 DATE,
+    CONSTRAINT chk_col1 CHECK (col1 > 0),
+    UNIQUE (col2)
+);
+
+-- Insert initial data into table_base1a
+INSERT INTO table_base1a (col1, col2) VALUES (1, 'text1'), (2, 'text2');
+-- Insert initial data into table_base2
+INSERT INTO table_base2 (col1, col2, col3) VALUES (1, 'unique_text1', '2023-01-01'), (2, 'unique_text2', '2023-01-02');
+
+-- Create table using LIKE including defaults and constraints
+CREATE TABLE table_l1 (LIKE table_base1a INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
+
+-- Validate table_l1
+-- Expected columns: col1 (without primary key), col2 (with default 'default_text')
+\d table_l1
+EXECUTE spocktab('table_l1'); -- should be in default_insert_only set
+
+
+-- Create table using LIKE excluding defaults
+CREATE TABLE table_l2 (LIKE table_base1a EXCLUDING DEFAULTS);
+
+-- Validate table_l2
+-- Expected columns: col1 (without primary key), col2 (without default)
+\d table_l2
+EXECUTE spocktab('table_l2'); -- should be in default_insert_only set
+
+
+-- Create table using LIKE including all properties
+CREATE TABLE table_l3 (LIKE table_base2 INCLUDING ALL);
+
+-- Validate table_l3
+-- Expected columns: col1, col2, col3 (with check constraint and unique constraint)
+\d table_l3
+EXECUTE spocktab('table_l3'); -- should be in default_insert_only set
+
+-- Create table using LIKE excluding constraints
+CREATE TABLE table_l4 (LIKE table_base2 EXCLUDING CONSTRAINTS);
+
+-- Validate table_l4
+-- Expected columns: col1, col2, col3 (without constraints)
+\d table_l4
+EXECUTE spocktab('table_l4'); -- should be in default_insert_only set
+
+-- Create table using LIKE including indexes
+CREATE TABLE table_l5 (LIKE table_base1a INCLUDING INDEXES);
+
+-- Validate table_l5
+-- Expected columns: col1 (primary key), col2 (without default), indexes copied
+\d table_l5
+EXECUTE spocktab('table_l5'); -- should be in default set
+
+
+-- Insert data into the LIKE created tables to validate defaults and constraints
+INSERT INTO table_l1 (col1) VALUES (3);
+INSERT INTO table_l2 (col1, col2) VALUES (4, 'text4');
+INSERT INTO table_l3 (col1, col2, col3) VALUES (3, 'unique_text3', '2023-01-03');
+INSERT INTO table_l4 (col1, col2, col3) VALUES (4, 'text4', '2023-01-04');
+INSERT INTO table_l5 (col1) VALUES (5);
+
+-- Validate data in table_l1 , Expected data: (3, 'default_text')
+SELECT * FROM table_l1;
+
+-- Validate data in table_l2 , Expected data: (4, 'text4')
+SELECT * FROM table_l2;
+
+-- Validate data in table_l3 , Expected data: (3, 'unique_text3', '2023-01-03')
+SELECT * FROM table_l3;
+
+-- Validate data in table_l4 ,  Expected data: (4, 'text4', '2023-01-04')
+SELECT * FROM table_l4;
+
+-- Validate data in table_l5, Expected data: (5, )
+SELECT * FROM table_l5;
+

--- a/test/t/auto_ddl/6111b_table_validate_and_drop_n2.out
+++ b/test/t/auto_ddl/6111b_table_validate_and_drop_n2.out
@@ -1,0 +1,610 @@
+-- 6111b - Validate and drop tables on n2
+-- Prepared statement for spock.tables so that we can execute it frequently in the script below
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname = $1 ORDER BY relid;
+PREPARE
+-- Validate sub_tx_table0
+-- Expected: table exists with column c of type int and primary key
+\d sub_tx_table0
+           Table "public.sub_tx_table0"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ c      | integer |           | not null | 
+Indexes:
+    "sub_tx_table0_pkey" PRIMARY KEY, btree (c)
+
+EXECUTE spocktab('sub_tx_table0'); -- Replication set: default
+ nspname |    relname    | set_name 
+---------+---------------+----------
+ public  | sub_tx_table0 | default
+(1 row)
+
+-- Validate sub_tx_table0a
+-- Expected: table does not exist
+\d sub_tx_table0a
+Did not find any relation named "sub_tx_table0a".
+-- Validate sub_tx_table1
+-- Expected: table does not exist
+\d sub_tx_table1
+Did not find any relation named "sub_tx_table1".
+-- Validate sub_tx_table2
+-- Expected: table exists with column c of type bigint
+\d sub_tx_table2
+           Table "public.sub_tx_table2"
+ Column |  Type  | Collation | Nullable | Default 
+--------+--------+-----------+----------+---------
+ c      | bigint |           |          | 
+
+EXECUTE spocktab('sub_tx_table2'); -- Replication set: default_insert_only
+ nspname |    relname    |      set_name       
+---------+---------------+---------------------
+ public  | sub_tx_table2 | default_insert_only
+(1 row)
+
+-- Validate sub_tx_table3
+-- Expected: table exists with columns a (smallint, primary key) and b (real)
+\d sub_tx_table3
+            Table "public.sub_tx_table3"
+ Column |   Type   | Collation | Nullable | Default 
+--------+----------+-----------+----------+---------
+ a      | smallint |           | not null | 
+ b      | real     |           |          | 
+Indexes:
+    "sub_tx_table3_pkey" PRIMARY KEY, btree (a)
+
+EXECUTE spocktab('sub_tx_table3'); -- Replication set: default
+ nspname |    relname    | set_name 
+---------+---------------+----------
+ public  | sub_tx_table3 | default
+(1 row)
+
+-- Expected data: (0, 0.09561), (42, 324.78), (56, 7.8), (100, 99.097), (777, 777.777)
+SELECT * FROM sub_tx_table3 ORDER BY a;
+  a  |    b    
+-----+---------
+   0 | 0.09561
+  42 |  324.78
+  56 |     7.8
+ 100 |  99.097
+ 777 | 777.777
+(5 rows)
+
+-- Validate sub_tx_table4
+-- Expected: table does not exist
+\d sub_tx_table4
+Did not find any relation named "sub_tx_table4".
+-- Validate sub_tx_table5, sub_tx_table5a, and sub_tx_table5c, sub_tx_table5b should not exist
+\d sub_tx_table5
+           Table "public.sub_tx_table5"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ c      | integer |           |          | 
+
+EXECUTE spocktab('sub_tx_table5'); -- Replication set: default_insert_only
+ nspname |    relname    |      set_name       
+---------+---------------+---------------------
+ public  | sub_tx_table5 | default_insert_only
+(1 row)
+
+\d sub_tx_table5a
+           Table "public.sub_tx_table5a"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ c      | integer |           | not null | 
+Indexes:
+    "sub_tx_table5a_pkey" PRIMARY KEY, btree (c)
+
+EXECUTE spocktab('sub_tx_table5a'); -- Replication set: default
+ nspname |    relname     | set_name 
+---------+----------------+----------
+ public  | sub_tx_table5a | default
+(1 row)
+
+\d sub_tx_table5b
+Did not find any relation named "sub_tx_table5b".
+\d sub_tx_table5c
+           Table "public.sub_tx_table5c"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ c      | integer |           |          | 
+
+EXECUTE spocktab('sub_tx_table5c'); -- Replication set: default_insert_only
+ nspname |    relname     |      set_name       
+---------+----------------+---------------------
+ public  | sub_tx_table5c | default_insert_only
+(1 row)
+
+-- Validate table_ctas1
+-- Expected: table exists with columns id (int), name (varchar), age (int)
+\d table_ctas1
+                   Table "public.table_ctas1"
+ Column |         Type          | Collation | Nullable | Default 
+--------+-----------------------+-----------+----------+---------
+ id     | integer               |           |          | 
+ name   | character varying(50) |           |          | 
+ age    | integer               |           |          | 
+
+EXECUTE spocktab('table_ctas1'); -- Replication set: default_insert_only
+ nspname |   relname   |      set_name       
+---------+-------------+---------------------
+ public  | table_ctas1 | default_insert_only
+(1 row)
+
+-- Expected data: (1, 'Alice', 30), (2, 'Bob', 25), (3, 'Carol', 35)
+SELECT * FROM table_ctas1 ORDER BY id;
+ id | name  | age 
+----+-------+-----
+  1 | Alice |  30
+  2 | Bob   |  25
+  3 | Carol |  35
+(3 rows)
+
+-- Validate table_ctas2
+-- Expected: table exists with columns id (int), age (int), primary key on id
+\d table_ctas2
+            Table "public.table_ctas2"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ id     | integer |           | not null | 
+ age    | integer |           |          | 
+Indexes:
+    "table_ctas2_pkey" PRIMARY KEY, btree (id)
+
+EXECUTE spocktab('table_ctas2'); -- Replication set: default
+ nspname |   relname   | set_name 
+---------+-------------+----------
+ public  | table_ctas2 | default
+(1 row)
+
+-- Expected data: (3, 35)
+SELECT * FROM table_ctas2 ORDER BY id;
+ id | age 
+----+-----
+  3 |  35
+(1 row)
+
+-- Validate table_ctas3
+-- Expected: table exists with columns id (int), value (int), primary key on id
+\d table_ctas3
+            Table "public.table_ctas3"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ id     | integer |           | not null | 
+ value  | integer |           |          | 
+Indexes:
+    "table_ctas3_pkey" PRIMARY KEY, btree (id)
+
+EXECUTE spocktab('table_ctas3'); -- Replication set: default
+ nspname |   relname   | set_name 
+---------+-------------+----------
+ public  | table_ctas3 | default
+(1 row)
+
+-- Expected data: (1, 10), (2, 20), (3, 30)
+SELECT * FROM table_ctas3 ORDER BY id;
+ id | value 
+----+-------
+  1 |    10
+  2 |    20
+  3 |    30
+(3 rows)
+
+-- Validate table_ctas4
+-- Expected: table exists with columns id (int), name (varchar), double_age (int), no data
+\d table_ctas4
+                     Table "public.table_ctas4"
+   Column   |         Type          | Collation | Nullable | Default 
+------------+-----------------------+-----------+----------+---------
+ id         | integer               |           |          | 
+ name       | character varying(50) |           |          | 
+ double_age | integer               |           |          | 
+
+EXECUTE spocktab('table_ctas4'); -- Replication set: default_insert_only
+ nspname |   relname   |      set_name       
+---------+-------------+---------------------
+ public  | table_ctas4 | default_insert_only
+(1 row)
+
+-- Expected data: empty (no data)
+SELECT * FROM table_ctas4 ORDER BY id;
+ id | name | double_age 
+----+------+------------
+(0 rows)
+
+-- Validate table_ctas5
+-- Expected: table exists with column num (int)
+\d table_ctas5
+            Table "public.table_ctas5"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ num    | integer |           |          | 
+
+EXECUTE spocktab('table_ctas5'); -- Replication set: default_insert_only
+ nspname |   relname   |      set_name       
+---------+-------------+---------------------
+ public  | table_ctas5 | default_insert_only
+(1 row)
+
+-- Expected data: 1 through 10
+SELECT * FROM table_ctas5 ORDER BY num;
+ num 
+-----
+   1
+   2
+   3
+   4
+   5
+   6
+   7
+   8
+   9
+  10
+(10 rows)
+
+-- Validate table_ctas6
+-- Expected: table exists with column a (int)
+\d table_ctas6
+            Table "public.table_ctas6"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ a      | integer |           |          | 
+
+EXECUTE spocktab('table_ctas6'); -- Replication set: default_insert_only
+ nspname |   relname   | set_name 
+---------+-------------+----------
+ public  | table_ctas6 | 
+(1 row)
+
+-- Expected data: 1
+SELECT * FROM table_ctas6 ORDER BY a;
+ a 
+---
+ 1
+(1 row)
+
+-- Validate table_si1
+-- Expected: table exists with columns id (int), column1 (text), column2 (int), column3 (date), column4 (boolean)
+\d table_si1
+              Table "public.table_si1"
+ Column  |  Type   | Collation | Nullable | Default 
+---------+---------+-----------+----------+---------
+ id      | integer |           |          | 
+ column1 | text    |           |          | 
+ column2 | integer |           |          | 
+ column3 | date    |           |          | 
+ column4 | boolean |           |          | 
+
+EXECUTE spocktab('table_si1'); -- Replication set: default_insert_only
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | table_si1 | default_insert_only
+(1 row)
+
+-- Expected data: (1, 'value1', 10, '2023-01-01', TRUE), (2, 'value2', 20, '2023-01-02', FALSE), (3, 'value3', 30, '2023-01-03', TRUE), (4, 'value4', 40, '2023-01-04', FALSE)
+SELECT * FROM table_si1 ORDER BY id;
+ id | column1 | column2 |  column3   | column4 
+----+---------+---------+------------+---------
+  1 | value1  |      10 | 2023-01-01 | t
+  2 | value2  |      20 | 2023-01-02 | f
+  3 | value3  |      30 | 2023-01-03 | t
+  4 | value4  |      40 | 2023-01-04 | f
+(4 rows)
+
+-- Validate table_si2
+-- Expected: table exists with columns id (int), column1 (text), column2 (int)
+\d table_si2
+              Table "public.table_si2"
+ Column  |  Type   | Collation | Nullable | Default 
+---------+---------+-----------+----------+---------
+ id      | integer |           |          | 
+ column1 | text    |           |          | 
+ column2 | integer |           |          | 
+
+EXECUTE spocktab('table_si2'); -- Replication set: default_insert_only
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | table_si2 | default_insert_only
+(1 row)
+
+-- Expected data: (3, 'value3', 30), (4, 'value4', 40)
+SELECT * FROM table_si2 ORDER BY id;
+ id | column1 | column2 
+----+---------+---------
+  3 | value3  |      30
+  4 | value4  |      40
+(2 rows)
+
+-- Validate table_si3
+-- Expected: table exists with columns column4 (boolean), count (int)
+\d table_si3
+              Table "public.table_si3"
+ Column  |  Type   | Collation | Nullable | Default 
+---------+---------+-----------+----------+---------
+ column4 | boolean |           |          | 
+ count   | bigint  |           |          | 
+
+EXECUTE spocktab('table_si3'); -- Replication set: default_insert_only
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | table_si3 | default_insert_only
+(1 row)
+
+-- Expected data: (TRUE, 2), (FALSE, 2)
+SELECT * FROM table_si3 ORDER BY column4;
+ column4 | count 
+---------+-------
+ f       |     2
+ t       |     2
+(2 rows)
+
+-- Validate table_si4
+-- Expected: table exists with columns id (int), column1 (text)
+\d table_si4
+              Table "public.table_si4"
+ Column  |  Type   | Collation | Nullable | Default 
+---------+---------+-----------+----------+---------
+ id      | integer |           |          | 
+ column1 | text    |           |          | 
+
+EXECUTE spocktab('table_si4'); -- Replication set: default_insert_only
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | table_si4 | default_insert_only
+(1 row)
+
+-- Expected data: (4, 'value4'), (3, 'value3')
+SELECT * FROM table_si4 ORDER BY id;
+ id | column1 
+----+---------
+  3 | value3
+  4 | value4
+(2 rows)
+
+-- Validate table_si5
+-- Expected: table exists with columns id (int), column1 (text), extra_data (varchar)
+\d table_si5
+                      Table "public.table_si5"
+   Column   |         Type          | Collation | Nullable | Default 
+------------+-----------------------+-----------+----------+---------
+ id         | integer               |           |          | 
+ column1    | text                  |           |          | 
+ extra_data | character varying(50) |           |          | 
+
+EXECUTE spocktab('table_si5'); -- Replication set: default_insert_only
+ nspname |  relname  |      set_name       
+---------+-----------+---------------------
+ public  | table_si5 | default_insert_only
+(1 row)
+
+-- Expected data: (1, 'value1', 'extra1'), (3, 'value3', 'extra3')
+SELECT * FROM table_si5 ORDER BY id;
+ id | column1 | extra_data 
+----+---------+------------
+  1 | value1  | extra1
+  3 | value3  | extra3
+(2 rows)
+
+-- Validate table_l1
+-- Expected: table exists with columns col1 (int), col2 (text, default 'default_text')
+\d table_l1
+                    Table "public.table_l1"
+ Column |  Type   | Collation | Nullable |       Default        
+--------+---------+-----------+----------+----------------------
+ col1   | integer |           | not null | 
+ col2   | text    |           |          | 'default_text'::text
+
+EXECUTE spocktab('table_l1'); -- Replication set: default_insert_repset
+ nspname | relname  |      set_name       
+---------+----------+---------------------
+ public  | table_l1 | default_insert_only
+(1 row)
+
+-- Expected data:  (3, 'default_text')
+SELECT * FROM table_l1 ORDER BY col1;
+ col1 |     col2     
+------+--------------
+    3 | default_text
+(1 row)
+
+-- Validate table_l2
+-- Expected: table exists with columns col1 (int, primary key), col2 (text)
+\d table_l2
+              Table "public.table_l2"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ col1   | integer |           | not null | 
+ col2   | text    |           |          | 
+
+EXECUTE spocktab('table_l2'); -- Replication set: default_insert_only
+ nspname | relname  |      set_name       
+---------+----------+---------------------
+ public  | table_l2 | default_insert_only
+(1 row)
+
+-- Expected data: (4, 'text4')
+SELECT * FROM table_l2 ORDER BY col1;
+ col1 | col2  
+------+-------
+    4 | text4
+(1 row)
+
+-- Validate table_l3
+-- Expected: table exists with columns col1 (int), col2 (text), col3 (date), check constraint, unique constraint
+\d table_l3
+              Table "public.table_l3"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ col1   | integer |           |          | 
+ col2   | text    |           |          | 
+ col3   | date    |           |          | 
+Indexes:
+    "table_l3_col2_key" UNIQUE CONSTRAINT, btree (col2)
+Check constraints:
+    "chk_col1" CHECK (col1 > 0)
+
+EXECUTE spocktab('table_l3'); -- Replication set: default_insert_only
+ nspname | relname  |      set_name       
+---------+----------+---------------------
+ public  | table_l3 | default_insert_only
+(1 row)
+
+-- Expected data: (3, 'unique_text3', '2023-01-03')
+SELECT * FROM table_l3 ORDER BY col1;
+ col1 |     col2     |    col3    
+------+--------------+------------
+    3 | unique_text3 | 2023-01-03
+(1 row)
+
+-- Validate table_l4
+-- Expected: table exists with columns col1 (int), col2 (text), col3 (date), no constraints
+\d table_l4
+              Table "public.table_l4"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ col1   | integer |           |          | 
+ col2   | text    |           |          | 
+ col3   | date    |           |          | 
+
+EXECUTE spocktab('table_l4'); -- Replication set: default_insert_only
+ nspname | relname  |      set_name       
+---------+----------+---------------------
+ public  | table_l4 | default_insert_only
+(1 row)
+
+-- Expected data: (4, 'text4', '2023-01-04')
+SELECT * FROM table_l4 ORDER BY col1;
+ col1 | col2  |    col3    
+------+-------+------------
+    4 | text4 | 2023-01-04
+(1 row)
+
+-- Validate table_l5
+-- Expected: table exists with columns col1 (int, primary key), col2 (text)
+\d table_l5
+              Table "public.table_l5"
+ Column |  Type   | Collation | Nullable | Default 
+--------+---------+-----------+----------+---------
+ col1   | integer |           | not null | 
+ col2   | text    |           |          | 
+Indexes:
+    "table_l5_pkey" PRIMARY KEY, btree (col1)
+
+EXECUTE spocktab('table_l5'); -- Replication set: default
+ nspname | relname  | set_name 
+---------+----------+----------
+ public  | table_l5 | default
+(1 row)
+
+-- Expected data: (5, )
+SELECT * FROM table_l5 ORDER BY col1;
+ col1 | col2 
+------+------
+    5 | 
+(1 row)
+
+----------------------------
+-- Cleanup: Drop all created tables
+-----------------------------
+-- Confirm autoDDL of DROP commands (and also to cleanup for all tables created in 6111a)
+--cleanup for tables ddl in transactions
+DROP TABLE sub_tx_table0;
+NOTICE:  drop cascades to table sub_tx_table0 membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE sub_tx_table2, sub_tx_table3;
+NOTICE:  drop cascades to table sub_tx_table2 membership in replication set default_insert_only
+NOTICE:  drop cascades to table sub_tx_table3 membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE sub_tx_table5, sub_tx_table5a, sub_tx_table5c;
+NOTICE:  drop cascades to table sub_tx_table5 membership in replication set default_insert_only
+NOTICE:  drop cascades to table sub_tx_table5a membership in replication set default
+NOTICE:  drop cascades to table sub_tx_table5c membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+--cleanup for tables used in ctas
+DROP TABLE table_base1;
+NOTICE:  drop cascades to table table_base1 membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_ctas1;
+NOTICE:  drop cascades to table table_ctas1 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_ctas2;
+NOTICE:  drop cascades to table table_ctas2 membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_ctas3;
+NOTICE:  drop cascades to table table_ctas3 membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_ctas4;
+NOTICE:  drop cascades to table table_ctas4 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_ctas5;
+NOTICE:  drop cascades to table table_ctas5 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_ctas6;
+INFO:  DDL statement replicated.
+DROP TABLE
+--cleanup for select into
+-- DROP commands for cleanup in 6111b
+DROP TABLE table_existing1;
+NOTICE:  drop cascades to table table_existing1 membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_existing2;
+NOTICE:  drop cascades to table table_existing2 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_si1;
+NOTICE:  drop cascades to table table_si1 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_si2;
+NOTICE:  drop cascades to table table_si2 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_si3;
+NOTICE:  drop cascades to table table_si3 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_si4;
+NOTICE:  drop cascades to table table_si4 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_si5;
+NOTICE:  drop cascades to table table_si5 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+-- DROP commands for cleanup in 6111b
+DROP TABLE table_base1a;
+NOTICE:  drop cascades to table table_base1a membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_base2;
+NOTICE:  drop cascades to table table_base2 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_l1;
+NOTICE:  drop cascades to table table_l1 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_l2;
+NOTICE:  drop cascades to table table_l2 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_l3;
+NOTICE:  drop cascades to table table_l3 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_l4;
+NOTICE:  drop cascades to table table_l4 membership in replication set default_insert_only
+INFO:  DDL statement replicated.
+DROP TABLE
+DROP TABLE table_l5;
+NOTICE:  drop cascades to table table_l5 membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE

--- a/test/t/auto_ddl/6111b_table_validate_and_drop_n2.sql
+++ b/test/t/auto_ddl/6111b_table_validate_and_drop_n2.sql
@@ -1,0 +1,197 @@
+-- 6111b - Validate and drop tables on n2
+
+-- Prepared statement for spock.tables so that we can execute it frequently in the script below
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname = $1 ORDER BY relid;
+
+-- Validate sub_tx_table0
+-- Expected: table exists with column c of type int and primary key
+\d sub_tx_table0
+EXECUTE spocktab('sub_tx_table0'); -- Replication set: default
+
+-- Validate sub_tx_table0a
+-- Expected: table does not exist
+\d sub_tx_table0a
+
+-- Validate sub_tx_table1
+-- Expected: table does not exist
+\d sub_tx_table1
+
+-- Validate sub_tx_table2
+-- Expected: table exists with column c of type bigint
+\d sub_tx_table2
+EXECUTE spocktab('sub_tx_table2'); -- Replication set: default_insert_only
+
+-- Validate sub_tx_table3
+-- Expected: table exists with columns a (smallint, primary key) and b (real)
+\d sub_tx_table3
+EXECUTE spocktab('sub_tx_table3'); -- Replication set: default
+-- Expected data: (0, 0.09561), (42, 324.78), (56, 7.8), (100, 99.097), (777, 777.777)
+SELECT * FROM sub_tx_table3 ORDER BY a;
+
+-- Validate sub_tx_table4
+-- Expected: table does not exist
+\d sub_tx_table4
+
+-- Validate sub_tx_table5, sub_tx_table5a, and sub_tx_table5c, sub_tx_table5b should not exist
+\d sub_tx_table5
+EXECUTE spocktab('sub_tx_table5'); -- Replication set: default_insert_only
+
+\d sub_tx_table5a
+EXECUTE spocktab('sub_tx_table5a'); -- Replication set: default
+
+\d sub_tx_table5b
+
+\d sub_tx_table5c
+EXECUTE spocktab('sub_tx_table5c'); -- Replication set: default_insert_only
+
+
+-- Validate table_ctas1
+-- Expected: table exists with columns id (int), name (varchar), age (int)
+\d table_ctas1
+EXECUTE spocktab('table_ctas1'); -- Replication set: default_insert_only
+-- Expected data: (1, 'Alice', 30), (2, 'Bob', 25), (3, 'Carol', 35)
+SELECT * FROM table_ctas1 ORDER BY id;
+
+-- Validate table_ctas2
+-- Expected: table exists with columns id (int), age (int), primary key on id
+\d table_ctas2
+EXECUTE spocktab('table_ctas2'); -- Replication set: default
+-- Expected data: (3, 35)
+SELECT * FROM table_ctas2 ORDER BY id;
+
+-- Validate table_ctas3
+-- Expected: table exists with columns id (int), value (int), primary key on id
+\d table_ctas3
+EXECUTE spocktab('table_ctas3'); -- Replication set: default
+-- Expected data: (1, 10), (2, 20), (3, 30)
+SELECT * FROM table_ctas3 ORDER BY id;
+
+-- Validate table_ctas4
+-- Expected: table exists with columns id (int), name (varchar), double_age (int), no data
+\d table_ctas4
+EXECUTE spocktab('table_ctas4'); -- Replication set: default_insert_only
+-- Expected data: empty (no data)
+SELECT * FROM table_ctas4 ORDER BY id;
+
+-- Validate table_ctas5
+-- Expected: table exists with column num (int)
+\d table_ctas5
+EXECUTE spocktab('table_ctas5'); -- Replication set: default_insert_only
+-- Expected data: 1 through 10
+SELECT * FROM table_ctas5 ORDER BY num;
+
+-- Validate table_ctas6
+-- Expected: table exists with column a (int)
+\d table_ctas6
+EXECUTE spocktab('table_ctas6'); -- Replication set: default_insert_only
+-- Expected data: 1
+SELECT * FROM table_ctas6 ORDER BY a;
+
+-- Validate table_si1
+-- Expected: table exists with columns id (int), column1 (text), column2 (int), column3 (date), column4 (boolean)
+\d table_si1
+EXECUTE spocktab('table_si1'); -- Replication set: default_insert_only
+-- Expected data: (1, 'value1', 10, '2023-01-01', TRUE), (2, 'value2', 20, '2023-01-02', FALSE), (3, 'value3', 30, '2023-01-03', TRUE), (4, 'value4', 40, '2023-01-04', FALSE)
+SELECT * FROM table_si1 ORDER BY id;
+
+-- Validate table_si2
+-- Expected: table exists with columns id (int), column1 (text), column2 (int)
+\d table_si2
+EXECUTE spocktab('table_si2'); -- Replication set: default_insert_only
+-- Expected data: (3, 'value3', 30), (4, 'value4', 40)
+SELECT * FROM table_si2 ORDER BY id;
+
+-- Validate table_si3
+-- Expected: table exists with columns column4 (boolean), count (int)
+\d table_si3
+EXECUTE spocktab('table_si3'); -- Replication set: default_insert_only
+-- Expected data: (TRUE, 2), (FALSE, 2)
+SELECT * FROM table_si3 ORDER BY column4;
+
+-- Validate table_si4
+-- Expected: table exists with columns id (int), column1 (text)
+\d table_si4
+EXECUTE spocktab('table_si4'); -- Replication set: default_insert_only
+-- Expected data: (4, 'value4'), (3, 'value3')
+SELECT * FROM table_si4 ORDER BY id;
+
+-- Validate table_si5
+-- Expected: table exists with columns id (int), column1 (text), extra_data (varchar)
+\d table_si5
+EXECUTE spocktab('table_si5'); -- Replication set: default_insert_only
+-- Expected data: (1, 'value1', 'extra1'), (3, 'value3', 'extra3')
+SELECT * FROM table_si5 ORDER BY id;
+
+-- Validate table_l1
+-- Expected: table exists with columns col1 (int), col2 (text, default 'default_text')
+\d table_l1
+EXECUTE spocktab('table_l1'); -- Replication set: default_insert_repset
+-- Expected data:  (3, 'default_text')
+SELECT * FROM table_l1 ORDER BY col1;
+
+-- Validate table_l2
+-- Expected: table exists with columns col1 (int, primary key), col2 (text)
+\d table_l2
+EXECUTE spocktab('table_l2'); -- Replication set: default_insert_only
+-- Expected data: (4, 'text4')
+SELECT * FROM table_l2 ORDER BY col1;
+
+-- Validate table_l3
+-- Expected: table exists with columns col1 (int), col2 (text), col3 (date), check constraint, unique constraint
+\d table_l3
+EXECUTE spocktab('table_l3'); -- Replication set: default_insert_only
+-- Expected data: (3, 'unique_text3', '2023-01-03')
+SELECT * FROM table_l3 ORDER BY col1;
+
+-- Validate table_l4
+-- Expected: table exists with columns col1 (int), col2 (text), col3 (date), no constraints
+\d table_l4
+EXECUTE spocktab('table_l4'); -- Replication set: default_insert_only
+-- Expected data: (4, 'text4', '2023-01-04')
+SELECT * FROM table_l4 ORDER BY col1;
+
+-- Validate table_l5
+-- Expected: table exists with columns col1 (int, primary key), col2 (text)
+\d table_l5
+EXECUTE spocktab('table_l5'); -- Replication set: default
+-- Expected data: (5, )
+SELECT * FROM table_l5 ORDER BY col1;
+
+----------------------------
+-- Cleanup: Drop all created tables
+-----------------------------
+-- Confirm autoDDL of DROP commands (and also to cleanup for all tables created in 6111a)
+
+--cleanup for tables ddl in transactions
+DROP TABLE sub_tx_table0;
+DROP TABLE sub_tx_table2, sub_tx_table3;
+DROP TABLE sub_tx_table5, sub_tx_table5a, sub_tx_table5c;
+
+--cleanup for tables used in ctas
+DROP TABLE table_base1;
+DROP TABLE table_ctas1;
+DROP TABLE table_ctas2;
+DROP TABLE table_ctas3;
+DROP TABLE table_ctas4;
+DROP TABLE table_ctas5;
+DROP TABLE table_ctas6;
+
+--cleanup for select into
+
+-- DROP commands for cleanup in 6111b
+DROP TABLE table_existing1;
+DROP TABLE table_existing2;
+DROP TABLE table_si1;
+DROP TABLE table_si2;
+DROP TABLE table_si3;
+DROP TABLE table_si4;
+DROP TABLE table_si5;
+
+-- DROP commands for cleanup in 6111b
+DROP TABLE table_base1a;
+DROP TABLE table_base2;
+DROP TABLE table_l1;
+DROP TABLE table_l2;
+DROP TABLE table_l3;
+DROP TABLE table_l4;
+DROP TABLE table_l5;

--- a/test/t/auto_ddl/6111c_table_validate_n1.out
+++ b/test/t/auto_ddl/6111c_table_validate_n1.out
@@ -1,0 +1,205 @@
+-- 6111c - Validate tables on n1
+-- Prepared statement for spock.tables so that we can execute it frequently in the script below
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname = $1 ORDER BY relid;
+PREPARE
+-- Validate sub_tx_table0
+-- Expected: table does not exist
+\d sub_tx_table0
+Did not find any relation named "sub_tx_table0".
+EXECUTE spocktab('sub_tx_table0');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate sub_tx_table2
+-- Expected: table does not exist
+\d sub_tx_table2
+Did not find any relation named "sub_tx_table2".
+EXECUTE spocktab('sub_tx_table2');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate sub_tx_table3
+-- Expected: table does not exist
+\d sub_tx_table3
+Did not find any relation named "sub_tx_table3".
+EXECUTE spocktab('sub_tx_table3');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate sub_tx_table5, sub_tx_table5a, sub_tx_table5c, sub_tx_table5b should not exist
+-- Expected: tables do not exist
+\d sub_tx_table5
+Did not find any relation named "sub_tx_table5".
+EXECUTE spocktab('sub_tx_table5');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+\d sub_tx_table5a
+Did not find any relation named "sub_tx_table5a".
+EXECUTE spocktab('sub_tx_table5a');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+\d sub_tx_table5b
+Did not find any relation named "sub_tx_table5b".
+EXECUTE spocktab('sub_tx_table5b'); -- should not exist
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+\d sub_tx_table5c
+Did not find any relation named "sub_tx_table5c".
+EXECUTE spocktab('sub_tx_table5c');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_ctas1
+-- Expected: table does not exist
+\d table_ctas1
+Did not find any relation named "table_ctas1".
+EXECUTE spocktab('table_ctas1');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_ctas2
+-- Expected: table does not exist
+\d table_ctas2
+Did not find any relation named "table_ctas2".
+EXECUTE spocktab('table_ctas2');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_ctas3
+-- Expected: table does not exist
+\d table_ctas3
+Did not find any relation named "table_ctas3".
+EXECUTE spocktab('table_ctas3');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_ctas4
+-- Expected: table does not exist
+\d table_ctas4
+Did not find any relation named "table_ctas4".
+EXECUTE spocktab('table_ctas4');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_ctas5
+-- Expected: table does not exist
+\d table_ctas5
+Did not find any relation named "table_ctas5".
+EXECUTE spocktab('table_ctas5');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_ctas6
+-- Expected: table does not exist
+\d table_ctas6
+Did not find any relation named "table_ctas6".
+EXECUTE spocktab('table_ctas6');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_si1
+-- Expected: table does not exist
+\d table_si1
+Did not find any relation named "table_si1".
+EXECUTE spocktab('table_si1');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_si2
+-- Expected: table does not exist
+\d table_si2
+Did not find any relation named "table_si2".
+EXECUTE spocktab('table_si2');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_si3
+-- Expected: table does not exist
+\d table_si3
+Did not find any relation named "table_si3".
+EXECUTE spocktab('table_si3');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_si4
+-- Expected: table does not exist
+\d table_si4
+Did not find any relation named "table_si4".
+EXECUTE spocktab('table_si4');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_si5
+-- Expected: table does not exist
+\d table_si5
+Did not find any relation named "table_si5".
+EXECUTE spocktab('table_si5');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_l1
+-- Expected: table does not exist
+\d table_l1
+Did not find any relation named "table_l1".
+EXECUTE spocktab('table_l1');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_l2
+-- Expected: table does not exist
+\d table_l2
+Did not find any relation named "table_l2".
+EXECUTE spocktab('table_l2');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_l3
+-- Expected: table does not exist
+\d table_l3
+Did not find any relation named "table_l3".
+EXECUTE spocktab('table_l3');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_l4
+-- Expected: table does not exist
+\d table_l4
+Did not find any relation named "table_l4".
+EXECUTE spocktab('table_l4');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+
+-- Validate table_l5
+-- Expected: table does not exist
+\d table_l5
+Did not find any relation named "table_l5".
+EXECUTE spocktab('table_l5');
+ nspname | relname | set_name 
+---------+---------+----------
+(0 rows)
+

--- a/test/t/auto_ddl/6111c_table_validate_n1.sql
+++ b/test/t/auto_ddl/6111c_table_validate_n1.sql
@@ -1,0 +1,110 @@
+-- 6111c - Validate tables on n1
+
+-- Prepared statement for spock.tables so that we can execute it frequently in the script below
+PREPARE spocktab AS SELECT nspname, relname, set_name FROM spock.tables WHERE relname = $1 ORDER BY relid;
+
+-- Validate sub_tx_table0
+-- Expected: table does not exist
+\d sub_tx_table0
+EXECUTE spocktab('sub_tx_table0');
+
+-- Validate sub_tx_table2
+-- Expected: table does not exist
+\d sub_tx_table2
+EXECUTE spocktab('sub_tx_table2');
+
+-- Validate sub_tx_table3
+-- Expected: table does not exist
+\d sub_tx_table3
+EXECUTE spocktab('sub_tx_table3');
+
+-- Validate sub_tx_table5, sub_tx_table5a, sub_tx_table5c, sub_tx_table5b should not exist
+-- Expected: tables do not exist
+\d sub_tx_table5
+EXECUTE spocktab('sub_tx_table5');
+\d sub_tx_table5a
+EXECUTE spocktab('sub_tx_table5a');
+\d sub_tx_table5b
+EXECUTE spocktab('sub_tx_table5b'); -- should not exist
+\d sub_tx_table5c
+EXECUTE spocktab('sub_tx_table5c');
+
+-- Validate table_ctas1
+-- Expected: table does not exist
+\d table_ctas1
+EXECUTE spocktab('table_ctas1');
+
+-- Validate table_ctas2
+-- Expected: table does not exist
+\d table_ctas2
+EXECUTE spocktab('table_ctas2');
+
+-- Validate table_ctas3
+-- Expected: table does not exist
+\d table_ctas3
+EXECUTE spocktab('table_ctas3');
+
+-- Validate table_ctas4
+-- Expected: table does not exist
+\d table_ctas4
+EXECUTE spocktab('table_ctas4');
+
+-- Validate table_ctas5
+-- Expected: table does not exist
+\d table_ctas5
+EXECUTE spocktab('table_ctas5');
+
+-- Validate table_ctas6
+-- Expected: table does not exist
+\d table_ctas6
+EXECUTE spocktab('table_ctas6');
+
+-- Validate table_si1
+-- Expected: table does not exist
+\d table_si1
+EXECUTE spocktab('table_si1');
+
+-- Validate table_si2
+-- Expected: table does not exist
+\d table_si2
+EXECUTE spocktab('table_si2');
+
+-- Validate table_si3
+-- Expected: table does not exist
+\d table_si3
+EXECUTE spocktab('table_si3');
+
+-- Validate table_si4
+-- Expected: table does not exist
+\d table_si4
+EXECUTE spocktab('table_si4');
+
+-- Validate table_si5
+-- Expected: table does not exist
+\d table_si5
+EXECUTE spocktab('table_si5');
+
+-- Validate table_l1
+-- Expected: table does not exist
+\d table_l1
+EXECUTE spocktab('table_l1');
+
+-- Validate table_l2
+-- Expected: table does not exist
+\d table_l2
+EXECUTE spocktab('table_l2');
+
+-- Validate table_l3
+-- Expected: table does not exist
+\d table_l3
+EXECUTE spocktab('table_l3');
+
+-- Validate table_l4
+-- Expected: table does not exist
+\d table_l4
+EXECUTE spocktab('table_l4');
+
+-- Validate table_l5
+-- Expected: table does not exist
+\d table_l5
+EXECUTE spocktab('table_l5');


### PR DESCRIPTION
This PR adds the test cases for AutoDDL functionality, organized in a three file structured format that will be followed for all future tests. Each test case set is split into three files:
- `a` file: Contains the main CREATE and ALTER operations on node n1.
- `b` file: Validates the auto-replicated DDL on node n2 and performs cleanup of replicated tables on n2 (exercising DROP, which auto-replicates and cleans up on n1).
- `c` file: Performs final validation on n1 to ensure all tables are dropped.

Whats included in this PR:
- **6100 Series tests**: 
  -  .sql and .out files (6100a_create_alter_table_n1, 6100b_validate_drop_table_n2, 6100c_validate_drop_n1)
  - Focuses on basic CREATE TABLE and ALTER TABLE operations with a wide variety of supported data types and constraints.

- **6111 Series tests**:
  - .sql and .out files ( 6111a_table_tx_ctas_selectinto_like, 6111b_table_validate_and_drop_n2, 6111c_table_validate_n1)
  - Covers advanced CREATE TABLE scenarios in transactions, CREATE TABLE AS, SELECT INTO, and CREATE TABLE LIKE with various options and constraints.