### PR TITLE
Add ACE as a CLI component

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -405,6 +405,7 @@ initPG () {
 
   initC "prompgexp"    "prompgexp"    "$prompgexpV" "$outPlat" "postgres/prompgexp" "" "" "nil"
   initC "m2m"          "m2m"          "$m2mV"       ""         "m2m"                "" "" "Y"
+  initC "ace"          "ace"          "$aceV"       ""         "ace"                "" "" "Y"
 
   ## initC "postgrest"    "postgrest"    "$postgrestV" "$outPlat" "postgres/postgrest" "" "" "nil"
   ## initC "prest"        "prest"        "$prestV"    "$outPlat" "pREST"             "" "" "nil"

--- a/cli/scripts/ace.py
+++ b/cli/scripts/ace.py
@@ -18,7 +18,6 @@ import psycopg
 import cluster
 import util
 import ace_db
-import ace_api
 import ace_config as config
 from ace_data_models import (
     RepsetDiffTask,
@@ -1226,6 +1225,5 @@ if __name__ == "__main__":
             "schema-diff": ace_cli.schema_diff_cli,
             "spock-diff": ace_cli.spock_diff_cli,
             "spock-exception-update": ace_cli.update_spock_exception_cli,
-            "start": ace_api.start_ace,
         }
     )

--- a/env.sh
+++ b/env.sh
@@ -4,6 +4,7 @@ hubVV=24.11-1
 bundle=pgedge
 api=pgedge
 ctlibsV=1.6
+aceV=2.0
 
 spock41V=4.1devel-1
 spock40V=4.0.5-1

--- a/src/ace/start-ace.py
+++ b/src/ace/start-ace.py
@@ -1,0 +1,58 @@
+import subprocess
+import os
+import psutil
+import sys
+import util
+
+log_file = "ace/ace_daemon.log"
+pid_file = "ace/ace_daemon.pid"
+
+
+def is_process_running(pid):
+    """Check if a process with the given PID is running."""
+    try:
+        return psutil.pid_exists(pid)
+    except Exception as e:
+        util.exit_message(f"Error checking process status: {e}")
+        return False
+
+
+def start_daemon():
+    """Start the ace_daemon process in the background and log its output."""
+    with open(log_file, "a") as log:
+        process = subprocess.Popen(
+            ["python", "-c", "import ace_daemon; ace_daemon.start_ace()"],
+            stdout=log,
+            stderr=log,
+            # Create a new session and process group for the daemon
+            # since ACE needs to create multiple subprocesses
+            preexec_fn=os.setsid,
+        )
+
+        with open(pid_file, "w") as pidf:
+            pidf.write(str(process.pid))
+
+        util.message(
+            f"ACE Daemon started with PID {process.pid}, logging to {log_file}"
+        )
+
+
+def main():
+    if os.path.exists(pid_file):
+        with open(pid_file, "r") as pidf:
+            pid = int(pidf.read().strip())
+
+        if is_process_running(pid):
+            util.exit_message(f"ACE Daemon is already running with PID {pid}. Exiting.")
+            sys.exit(0)
+        else:
+            util.message(
+                f"Stale PID file found for PID {pid}. Starting new daemon instance."
+            )
+            os.remove(pid_file)
+
+    start_daemon()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ace/stop-ace.py
+++ b/src/ace/stop-ace.py
@@ -1,0 +1,45 @@
+import os
+import signal
+import psutil
+
+import util
+
+pid_file = "ace/ace_daemon.pid"
+
+
+def is_process_running(pid):
+    """Check if a process with the given PID is running."""
+    try:
+        return psutil.pid_exists(pid)
+    except Exception as e:
+        util.exit_message(f"Error checking process status: {e}")
+        return False
+
+
+def stop_daemon():
+    """Stop the running ace_daemon process if it's running."""
+    try:
+        if os.path.exists(pid_file):
+            with open(pid_file, "r") as pidf:
+                pid = int(pidf.read().strip())
+
+            if is_process_running(pid):
+                os.killpg(os.getpgid(pid), signal.SIGTERM)
+                util.message(
+                    f"ACE Daemon and its subprocesses have been stopped (PID: {pid})."
+                )
+            else:
+                util.message(
+                    f"No running process found for PID {pid}."
+                    " Cleaning up stale PID file."
+                )
+
+            os.remove(pid_file)
+        else:
+            util.message("No PID file found. Daemon may not be running.")
+    except Exception as e:
+        util.exit_message(f"Error stopping ACE Daemon: {e}")
+
+
+if __name__ == "__main__":
+    stop_daemon()

--- a/src/conf/versions.sql
+++ b/src/conf/versions.sql
@@ -143,6 +143,7 @@ INSERT INTO products VALUES ('ha', 3, 'backrest');
 INSERT INTO products VALUES ('ai', 1, 'pgml');
 INSERT INTO products VALUES ('ai', 2, 'vector');
 INSERT INTO products VALUES ('ai', 3, 'aifdw');
+INSERT INTO products VALUES ('ace', 1, 'ace');
 
 CREATE VIEW v_products AS
 SELECT p.product, p.seqnce, p.project, r.component, v.version,
@@ -531,6 +532,13 @@ INSERT INTO releases VALUES ('backrest', 2, 'backrest',  'pgBackRest', '', 'test
 INSERT INTO versions VALUES ('backrest', '2.53.1-1', 'amd, arm', 1, '20240912', '', '', '');
 INSERT INTO versions VALUES ('backrest', '2.53-1',   'amd, arm', 0, '20240729', '', '', '');
 INSERT INTO versions VALUES ('backrest', '2.52-1',   'amd, arm', 0, '20240612', '', '', '');
+
+
+-- ## ACE ##########################
+INSERT INTO projects VALUES ('ace', 'pge', 11, 5000, '', 3, 'http://github.com/pgedge/cli/cli/scripts/ace.py',
+  'ace',  0, '', 'Anti Chaos Engine for pgEdge', 'https://github.com/pgedge/cli/cli/scripts/ace.py', 'ace');
+INSERT INTO releases VALUES ('ace', 2, 'ace',  'ACE', '', 'test', '', 1, 'POSTGRES', '', '');
+INSERT INTO versions VALUES ('ace', '2.0', '', 1, '20241002', '', '', '');
 
 -- ## FIREWALLD #########################
 INSERT INTO projects VALUES ('firewalld', 'app', 11, 0, '', 4, 'https://firewalld.org',


### PR DESCRIPTION
* This PR adds ACE as a CLI component by integrating into the build process. Running a `./pgedge install ace` will ensure that ACE can be used in the daemon mode and can be started and stopped using `./pgedge start ace` and `./pgedge stop ace`.
* `ace-start.py` and `ace-stop.py` start and stop ACE, respectively, by creating PID files and logging the subprocess output to a file.
* The ace-daemon is started as a subprocess process group (by using `os.setsid`) in its own session. This is to ensure that all ACE subprocesses are in their own process group and treated as a single unit to avoid issues during multiprocess spawns, logouts, logging, starting/stopping, etc.