### PR TITLE
ACE html reporting

### DIFF
--- a/cli/scripts/ace-tests/ace_test.py
+++ b/cli/scripts/ace-tests/ace_test.py
@@ -252,12 +252,13 @@ class TestSimple:
 
             # Verify the number of differences matches our modifications
             assert (
-                len(diff_data["n1/n2"]["n2"]) == 50
-            ), f"Expected 50 differences, but found {len(diff_data['n1/n2']['n2'])}"
+                len(diff_data["diffs"]["n1/n2"]["n2"]) == 50
+            ), "Expected 50 differences,"
+            f" but found {len(diff_data['diffs']['n1/n2']['n2'])}"
 
             # Verify each modified row is present in the diff
             diff_indices = {
-                diff[key_column] for diff in diff_data["n1/n2"]["n2"]
+                diff[key_column] for diff in diff_data["diffs"]["n1/n2"]["n2"]
             }  # Set of indices from diff file
 
             assert (
@@ -265,13 +266,13 @@ class TestSimple:
             ), "Modified rows don't match diff file records"
 
             # Verify the differences are correctly reported
-            for diff in diff_data["n1/n2"]["n2"]:
+            for diff in diff_data["diffs"]["n1/n2"]["n2"]:
                 assert diff[column_name].endswith(
                     "-modified"
                 ), f"Modified row {diff[key_column]} doesn't have expected suffix"
 
             # Verify the control rows are not modified
-            for diff in diff_data["n1/n2"]["n1"]:
+            for diff in diff_data["diffs"]["n1/n2"]["n1"]:
                 assert not diff[column_name].endswith(
                     "-modified"
                 ), f"Control row {diff[key_column]} shouldn't have modification suffix"
@@ -371,9 +372,9 @@ class TestSimple:
             diff_data = json.load(f)
 
         # Verify the diff file is correct
-        assert len(diff_data["n1/n2"]["n2"]) == 100, "Expected 100 differences"
+        assert len(diff_data["diffs"]["n1/n2"]["n2"]) == 100, "Expected 100 differences"
 
-        for diff in diff_data["n1/n2"]["n2"]:
+        for diff in diff_data["diffs"]["n1/n2"]["n2"]:
             assert diff["city"] == "Casablanca", "Expected city to be 'Casablanca'"
 
     @pytest.mark.parametrize("table_name", ["public.customers"])
@@ -407,10 +408,10 @@ class TestSimple:
             diff_data = json.load(f)
 
         # Verify we still have 100 diffs
-        assert len(diff_data["n1/n2"]["n2"]) == 100, "Expected 100 differences"
+        assert len(diff_data["diffs"]["n1/n2"]["n2"]) == 100, "Expected 100 differences"
 
         # Verify the diffs are correct
-        for diff in diff_data["n1/n2"]["n2"]:
+        for diff in diff_data["diffs"]["n1/n2"]["n2"]:
             assert diff["city"] == "Casablanca", "Expected city to be 'Casablanca'"
 
         # Now that we have verified diffs through both methods, we can use repair
@@ -795,17 +796,20 @@ class TestDataTypes(TestSimple):
 
             # Verify number of differences
             assert (
-                len(diff_data["n1/n2"]["n2"]) == 3
-            ), f"Expected 50 differences, found {len(diff_data['n1/n2']['n2'])}"
+                len(diff_data["diffs"]["n1/n2"]["n2"]) == 3
+            ), "Expected 3 differences,"
+            f" found {len(diff_data['diffs']['n1/n2']['n2'])}"
 
             # Verify modified rows are in diff
-            diff_indices = {str(diff["id"]) for diff in diff_data["n1/n2"]["n2"]}
+            diff_indices = {
+                str(diff["id"]) for diff in diff_data["diffs"]["n1/n2"]["n2"]
+            }
             assert (
                 modified_indices == diff_indices
             ), "Modified rows don't match diff file records"
 
             # Verify the differences are correctly reported
-            for diff in diff_data["n1/n2"]["n2"]:
+            for diff in diff_data["diffs"]["n1/n2"]["n2"]:
                 if column_name == "json_col":
                     assert (
                         diff[column_name].get("test") == "modified"
@@ -903,11 +907,11 @@ class TestDataTypes(TestSimple):
             diff_data = json.load(f)
 
         assert (
-            len(diff_data["n1/n2"]["n2"]) == 3
-        ), f"Expected 3 differences, found {len(diff_data['n1/n2']['n2'])}"
+            len(diff_data["diffs"]["n1/n2"]["n2"]) == 3
+        ), f"Expected 3 differences, found {len(diff_data['diffs']['n1/n2']['n2'])}"
 
         # Verify the differences are correctly reported
-        for diff in diff_data["n1/n2"]["n2"]:
+        for diff in diff_data["diffs"]["n1/n2"]["n2"]:
             if column_name == "json_col":
                 assert (
                     diff[column_name].get("rerun") == "modified"
@@ -1003,11 +1007,11 @@ class TestDataTypes(TestSimple):
             diff_data = json.load(f)
 
         assert (
-            len(diff_data["n1/n2"]["n2"]) == 3
-        ), f"Expected 3 differences, found {len(diff_data['n1/n2']['n2'])}"
+            len(diff_data["diffs"]["n1/n2"]["n2"]) == 3
+        ), f"Expected 3 differences, found {len(diff_data['diffs']['n1/n2']['n2'])}"
 
         # Verify the differences are correctly reported
-        for diff in diff_data["n1/n2"]["n2"]:
+        for diff in diff_data["diffs"]["n1/n2"]["n2"]:
             if column_name == "json_col":
                 assert (
                     diff[column_name].get("multiproc") == "modified"
@@ -1078,7 +1082,7 @@ class TestTableFilter:
             cur = conn.cursor()
             cur.execute(
                 f"""
-                UPDATE customers 
+                UPDATE customers
                 SET {column_name} = {column_name} || '-modified'
                 WHERE index < 50
                 RETURNING index, {column_name}
@@ -1114,9 +1118,10 @@ class TestTableFilter:
 
             # Verify all differences are within filter range
             assert (
-                len(diff_data["n1/n2"]["n2"]) == 49
-            ), f"Expected 49 differences, found {len(diff_data['n1/n2']['n2'])}"
-            for diff in diff_data["n1/n2"]["n2"]:
+                len(diff_data["diffs"]["n1/n2"]["n2"]) == 49
+            ), "Expected 49 differences,"
+            f" found {len(diff_data['diffs']['n1/n2']['n2'])}"
+            for diff in diff_data["diffs"]["n1/n2"]["n2"]:
                 assert (
                     diff["index"] < 100
                 ), f"Found diff outside filter range: index = {diff['index']}"
@@ -1194,7 +1199,7 @@ class TestTableFilter:
             cur = conn.cursor()
             cur.execute(
                 """
-                UPDATE customers 
+                UPDATE customers
                 SET city = 'FilterCity'
                 WHERE index < 50
             """
@@ -1227,9 +1232,7 @@ class TestTableFilter:
             )
             captured = capsys.readouterr()
             output = captured.out
-            clean_output = re.sub(
-                r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", output
-            )
+            clean_output = re.sub(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", output)
 
             match = re.search(r"diffs written out to (.+\.json)", clean_output.lower())
             assert match, "Diff file path not found in output"
@@ -1244,9 +1247,9 @@ class TestTableFilter:
                 diff_data = json.load(f)
 
             assert (
-                len(diff_data["n1/n2"]["n2"]) == 49
+                len(diff_data["diffs"]["n1/n2"]["n2"]) == 49
             ), f"Expected 49 differences for {behavior}"
-            for diff in diff_data["n1/n2"]["n2"]:
+            for diff in diff_data["diffs"]["n1/n2"]["n2"]:
                 assert (
                     diff["index"] < 100
                 ), f"Found diff outside filter range in {behavior}"

--- a/cli/scripts/ace.py
+++ b/cli/scripts/ace.py
@@ -676,9 +676,9 @@ def table_diff_checks(td_task: TableDiffTask) -> TableDiffTask:
             "Invalid value range for ACE_MAX_CPU_RATIO or --max_cpu_ratio"
         )
 
-    if td_task.output not in ["csv", "json"]:
+    if td_task.output not in ["csv", "json", "html"]:
         raise AceException(
-            "table-diff currently supports only csv and json output formats"
+            "table-diff currently supports only csv, json and html output formats"
         )
 
     node_list = []

--- a/cli/scripts/ace.py
+++ b/cli/scripts/ace.py
@@ -439,6 +439,68 @@ def check_column_size(conn_list: list, task: TableDiffTask) -> tuple[bool, str]:
     return True, ""
 
 
+def check_diff_file_format(diff_file_path: str, task) -> dict:
+    """
+    If the diff-file is not a valid json, then we throw an error message and exit.
+    However, if the diff-file is a valid json, it's a slightly trickier case.
+    Our diff-file is a json of the form:
+    {
+        "diffs": {
+            "node1/node2": {
+                "node1": [{"col1": "val1", "col2": "val2", ...}, ...],
+                "node2": [{"col1": "val1", "col2": "val2", ...}, ...]
+            },
+            "node1/node3": {
+                "node1": [{"col1": "val1", "col2": "val2", ...}, ...],
+                "node3": [{"col1": "val1", "col2": "val2", ...}, ...]
+            }
+        },
+        "summary": {...}
+
+    }
+
+    We need to make sure that the root-level keys are of the form "node1/node2" and
+    that the inner keys have the corresponding node names. E.g., if the root-level key
+    is "node1/node2", then the inner keys should be "node1" and "node2".
+
+    A simple way we achieve this is by iterating over the root keys and checking if the
+    inner keys are contained in the list when the root key is split by "/". If not, we
+    throw an error message and exit.
+
+    TODO: It might be possible that the diff file has different cols compared to the
+    target table. We need to handle this case.
+    """
+    try:
+        diff_json = json.loads(open(diff_file_path, "r").read())
+    except Exception as e:
+        context = {"errors": [f"Could not load diff file as JSON: {str(e)}"]}
+        handle_task_exception(task, context)
+        raise e
+
+    try:
+        if any(
+            [
+                set(list(diff_json["diffs"][k].keys())) != set(k.split("/"))
+                for k in diff_json["diffs"].keys()
+            ]
+        ):
+            raise AceException("Contents of diff file improperly formatted")
+
+        diff_json = {
+            node_pair: {
+                node: [{key: str(val) for key, val in row.items()} for row in rows]
+                for node, rows in nodes_data.items()
+            }
+            for node_pair, nodes_data in diff_json["diffs"].items()
+        }
+    except Exception as e:
+        context = {"errors": [f"Could not read diff file: {str(e)}"]}
+        handle_task_exception(task, context)
+        raise e
+
+    return diff_json
+
+
 def write_diffs_json(td_task, diff_dict, col_types, quiet_mode=False):
 
     # TODO: Need to revisit this.
@@ -955,24 +1017,7 @@ def table_diff_checks(td_task: TableDiffTask) -> TableDiffTask:
         )
 
     if td_task.diff_file_path:
-        if not os.path.exists(td_task.diff_file_path):
-            raise AceException(f"Diff file {td_task.diff_file_path} not found")
-
-        try:
-            diff_data = json.load(open(td_task.diff_file_path, "r"))
-        except Exception as e:
-            raise AceException(f"Could not load diff file as JSON: {e}")
-
-        try:
-            if any(
-                [
-                    set(list(diff_data[k].keys())) != set(k.split("/"))
-                    for k in diff_data.keys()
-                ]
-            ):
-                raise AceException("Contents of diff file improperly formatted")
-        except Exception as e:
-            raise AceException(f"Contents of diff file improperly formatted: {e}")
+        check_diff_file_format(td_task.diff_file_path, td_task)
 
     # Finally, we will replace the table name with the view name if necessary
     if td_task.table_filter:

--- a/cli/scripts/ace_core.py
+++ b/cli/scripts/ace_core.py
@@ -18,6 +18,7 @@ from dateutil import parser
 import pgpasslib
 import ace
 import ace_db
+import ace_html_reporter
 import cluster
 import util
 import ace_config as config
@@ -679,13 +680,18 @@ def table_diff(td_task: TableDiffTask):
             )
 
         try:
-            if td_task.output == "json":
+            if td_task.output == "json" or td_task.output == "html":
                 td_task.diff_file_path = ace.write_diffs_json(
                     td_task,
                     diff_dict,
                     td_task.fields.col_types,
                     quiet_mode=td_task.quiet_mode,
                 )
+
+                if td_task.output == "html":
+                    ace_html_reporter.generate_html(
+                        td_task.diff_file_path, td_task.fields.key.split(",")
+                    )
             elif td_task.output == "csv":
                 ace.write_diffs_csv(diff_dict)
         except Exception as e:

--- a/cli/scripts/ace_data_models.py
+++ b/cli/scripts/ace_data_models.py
@@ -54,6 +54,8 @@ class TableDiffTask:
     # and is not mandatory
     diff_file_path: str = None
 
+    diff_summary: dict = field(default_factory=dict)
+
     # If we're invoking table-diff from repset-diff,
     # we don't need to update the database with the
     # status of each table-diff task (for now)

--- a/cli/scripts/ace_html_reporter.py
+++ b/cli/scripts/ace_html_reporter.py
@@ -46,7 +46,8 @@ def generate_html(diff_file, pkey_list):
             }
 
             body {
-                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+                Helvetica, Arial, sans-serif;
                 line-height: 1.5;
                 color: var(--text-primary);
                 background-color: var(--bg-secondary);
@@ -225,7 +226,7 @@ def generate_html(diff_file, pkey_list):
                 .container {
                     padding: 0 0.5rem;
                 }
-                
+
                 .summary-grid {
                     grid-template-columns: 1fr;
                 }

--- a/cli/scripts/ace_html_reporter.py
+++ b/cli/scripts/ace_html_reporter.py
@@ -1,0 +1,481 @@
+import json
+import html
+
+import util
+
+
+def format_duration(seconds):
+    """Format duration in seconds to a human-readable string"""
+    if seconds < 60:
+        return f"{seconds:.1f} seconds"
+    minutes = seconds // 60
+    remaining_seconds = seconds % 60
+    return f"{int(minutes)} minutes {remaining_seconds:.1f} seconds"
+
+
+def generate_html(diff_file, pkey_list):
+    """Generate HTML report from diff file"""
+    with open(diff_file, "r") as f:
+        data = json.load(f)
+
+    diffs = data["diffs"]
+    summary = data["summary"]
+
+    html_content = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>ACE Table Diff Report</title>
+        <style>
+            :root {
+                --primary-color: #0366d6;
+                --success-color: #28a745;
+                --warning-color: #ffc107;
+                --danger-color: #dc3545;
+                --text-primary: #24292e;
+                --text-secondary: #586069;
+                --bg-primary: #ffffff;
+                --bg-secondary: #f6f8fa;
+                --border-color: #e1e4e8;
+            }
+
+            * {
+                margin: 0;
+                padding: 0;
+                box-sizing: border-box;
+            }
+
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+                line-height: 1.5;
+                color: var(--text-primary);
+                background-color: var(--bg-secondary);
+            }
+
+            .container {
+                max-width: 1400px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+            }
+
+            h1, h2 {
+                color: var(--text-primary);
+                font-weight: 600;
+                margin-bottom: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+                padding-bottom: 0.5rem;
+                border-bottom: 1px solid var(--border-color);
+            }
+
+            h2 {
+                font-size: 1.5rem;
+            }
+
+            .summary-box {
+                background: var(--bg-primary);
+                border: 1px solid var(--border-color);
+                border-radius: 6px;
+                padding: 1.5rem;
+                margin: 1.5rem 0;
+                box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+            }
+
+            .summary-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+                gap: 1.5rem;
+            }
+
+            .summary-item {
+                padding: 1rem;
+                background: var(--bg-secondary);
+                border-radius: 6px;
+                transition: transform 0.2s ease, box-shadow 0.2s ease;
+            }
+
+            .summary-item:hover {
+                transform: translateY(-2px);
+                box-shadow: 0 4px 8px rgba(0,0,0,0.08);
+            }
+
+            .summary-label {
+                font-size: 0.875rem;
+                font-weight: 500;
+                color: var(--text-secondary);
+                margin-bottom: 0.25rem;
+            }
+
+            .summary-value {
+                font-size: 1.125rem;
+                font-weight: 600;
+                color: var(--text-primary);
+            }
+
+            .diff-section {
+                background: var(--bg-primary);
+                border: 1px solid var(--border-color);
+                border-radius: 6px;
+                margin: 1.5rem 0;
+                overflow: hidden;
+                box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+            }
+
+            .diff-header {
+                background: var(--primary-color);
+                color: white;
+                padding: 1rem 1.5rem;
+                font-size: 1.125rem;
+                font-weight: 500;
+            }
+
+            table {
+                width: 100%;
+                border-collapse: separate;
+                border-spacing: 0;
+                font-size: 0.875rem;
+            }
+
+            th {
+                background: var(--bg-secondary);
+                padding: 0.75rem 1rem;
+                text-align: left;
+                font-weight: 600;
+                color: var(--text-secondary);
+                border-bottom: 2px solid var(--border-color);
+                position: sticky;
+                top: 0;
+                z-index: 10;
+            }
+
+            td {
+                padding: 0.75rem 1rem;
+                border-bottom: 1px solid var(--border-color);
+                transition: background-color 0.15s ease;
+            }
+
+            tr:hover td {
+                background-color: var(--bg-secondary);
+            }
+
+            .different {
+                background-color: #ffeef0;
+                color: var(--danger-color);
+            }
+
+            .different::before {
+                position: absolute;
+                left: 0.25rem;
+                color: var(--danger-color);
+                opacity: 0.5;
+            }
+
+            .key-column {
+                font-weight: 600;
+                color: var(--primary-color);
+            }
+
+            .missing {
+                background-color: #fff8e6;
+                color: #856404;
+                font-style: italic;
+            }
+
+            .row-separator {
+                background: var(--primary-color);
+                color: white;
+                font-weight: 500;
+                text-align: center;
+                padding: 0.75rem;
+            }
+
+            .row-divider {
+                height: 0.5rem;
+                background: var(--bg-secondary);
+            }
+
+            .row-subseparator {
+                background: var(--bg-secondary);
+                color: var(--text-secondary);
+                font-weight: 500;
+                text-align: center;
+                padding: 0.5rem;
+                font-size: 0.875rem;
+            }
+
+            @keyframes fadeIn {
+                from { opacity: 0; transform: translateY(10px); }
+                to { opacity: 1; transform: translateY(0); }
+            }
+
+            .summary-item {
+                animation: fadeIn 0.3s ease-out forwards;
+            }
+
+            .summary-item:nth-child(1) { animation-delay: 0.1s; }
+            .summary-item:nth-child(2) { animation-delay: 0.2s; }
+            .summary-item:nth-child(3) { animation-delay: 0.3s; }
+            .summary-item:nth-child(4) { animation-delay: 0.4s; }
+            .summary-item:nth-child(5) { animation-delay: 0.5s; }
+            .summary-item:nth-child(6) { animation-delay: 0.6s; }
+
+            @media (max-width: 768px) {
+                .container {
+                    padding: 0 0.5rem;
+                }
+                
+                .summary-grid {
+                    grid-template-columns: 1fr;
+                }
+
+                td, th {
+                    padding: 0.5rem;
+                }
+            }
+        </style>
+    </head>
+    """
+
+    html_content += f"""
+    <body>
+        <div class="container">
+            <h1>ACE Table Diff Report</h1>
+
+            <!-- Summary Section -->
+            <div class="summary-box">
+                <h2>Summary</h2>
+                <div class="summary-grid">
+                    <div class="summary-item">
+                        <div class="summary-label">Task ID</div>
+                        <div class="summary-value">{summary['task_id']}</div>
+                    </div>
+                    <div class="summary-item">
+                        <div class="summary-label">Table</div>
+                        <div class="summary-value">
+                            {summary['schema_name']}.{summary['table_name']}
+                        </div>
+                    </div>
+                    <div class="summary-item">
+                        <div class="summary-label">Total Rows Checked</div>
+                        <div class="summary-value">
+                            {summary['total_rows_checked']:,}
+                        </div>
+                    </div>
+                    <div class="summary-item">
+                        <div class="summary-label">Time Taken</div>
+                        <div class="summary-value">
+                            {format_duration(summary['time_taken'])}
+                        </div>
+                    </div>
+                    <div class="summary-item">
+                        <div class="summary-label">Start Time</div>
+                        <div class="summary-value">{summary['start_time']}</div>
+                    </div>
+                    <div class="summary-item">
+                        <div class="summary-label">End Time</div>
+                        <div class="summary-value">{summary['end_time']}</div>
+                    </div>
+                </div>
+            </div>
+    """
+
+    # Add diff sections for each node pair
+    for node_pair, pair_diffs in diffs.items():
+        node1, node2 = node_pair.split("/")
+        diff_count = summary["diff_count"][node_pair]
+
+        # Get all possible columns from both nodes
+        columns = set()
+        for node_data in pair_diffs.values():
+            for row in node_data:
+                columns.update(row.keys())
+
+        # Move key columns to front
+        columns = sorted(list(columns))
+        for key in pkey_list:
+            if key in columns:
+                columns.remove(key)
+                columns.insert(0, key)
+
+        html_content += f"""
+            <div class="diff-section">
+                <div class="diff-header">
+                    Differences between {node1} and {node2} ({diff_count} differences)
+                </div>
+                <table>
+                    <tr>
+                        <th>Column</th>
+                        <th>{node1}</th>
+                        <th>{node2}</th>
+                    </tr>
+        """
+
+        # Create sets of primary key values for each node
+        def get_key_tuple(row):
+            return tuple(str(row.get(key, "")) for key in pkey_list if key in columns)
+
+        node1_keys = {get_key_tuple(row) for row in pair_diffs[node1]}
+        node2_keys = {get_key_tuple(row) for row in pair_diffs[node2]}
+
+        # Find missing rows
+        missing_in_node2 = node1_keys - node2_keys
+        missing_in_node1 = node2_keys - node1_keys
+        common_keys = node1_keys & node2_keys
+
+        # Create lookup dictionaries for faster access
+        node1_rows = {get_key_tuple(row): row for row in pair_diffs[node1]}
+        node2_rows = {get_key_tuple(row): row for row in pair_diffs[node2]}
+
+        # First show rows that exist in both nodes but have differences
+        if common_keys:
+            html_content += (
+                '<tr><td colspan="3" class="row-separator">'
+                "Value Differences</td></tr>"
+            )
+
+            for i, key in enumerate(common_keys):
+                if i > 0:  # Add separator between rows
+                    html_content += '<tr><td colspan="3" class="row-divider"></td></tr>'
+
+                row1 = node1_rows[key]
+                row2 = node2_rows[key]
+
+                for col in columns:
+                    val1 = str(row1.get(col, ""))
+                    val2 = str(row2.get(col, ""))
+                    different = val1 != val2
+                    is_key = col in pkey_list
+
+                    html_content += f"""
+                        <tr>
+                            <td class="{
+                                'key-column' if is_key else ''
+                            }">{html.escape(col)}</td>
+                            <td class="{
+                                'different' if different else ''
+                            }">{html.escape(val1)}</td>
+                            <td class="{
+                                'different' if different else ''
+                            }">{html.escape(val2)}</td>
+                        </tr>
+                    """
+
+        # Show all missing rows under one section
+        if missing_in_node1 or missing_in_node2:
+            html_content += (
+                '<tr><td colspan="3" class="row-separator">'
+                "Missing Rows</td></tr>"
+            )
+
+            # Show rows missing in node2
+            if missing_in_node2:
+                for i, key in enumerate(missing_in_node2):
+                    if i > 0:  # Add separator between rows
+                        html_content += (
+                            '<tr><td colspan="3" class="row-divider"></td></tr>'
+                        )
+
+                    html_content += (
+                        f'<tr><td colspan="3" class="row-subseparator">'
+                        f"Missing in {node2}</td></tr>"
+                    )
+
+                    row1 = node1_rows[key]
+                    for col in columns:
+                        val1 = str(row1.get(col, ""))
+                        is_key = col in pkey_list
+
+                        html_content += f"""
+                            <tr>
+                                <td class="{
+                                    'key-column' if is_key else ''
+                                }">{html.escape(col)}</td>
+                                <td>{html.escape(val1)}</td>
+                                <td class="missing">MISSING</td>
+                            </tr>
+                        """
+
+            # Show rows missing in node1
+            if missing_in_node1:
+                for i, key in enumerate(missing_in_node1):
+                    if i > 0:  # Add separator between rows
+                        html_content += (
+                            '<tr><td colspan="3" class="row-divider"></td></tr>'
+                        )
+
+                    html_content += (
+                        f'<tr><td colspan="3" class="row-subseparator">'
+                        f"Missing in {node1}</td></tr>"
+                    )
+
+                    row2 = node2_rows[key]
+                    for col in columns:
+                        val2 = str(row2.get(col, ""))
+                        is_key = col in pkey_list
+
+                        html_content += f"""
+                            <tr>
+                                <td class="{
+                                    'key-column' if is_key else ''
+                                }">{html.escape(col)}</td>
+                                <td class="missing">MISSING</td>
+                                <td>{html.escape(val2)}</td>
+                            </tr>
+                        """
+
+        html_content += "</table></div>"
+
+    # Add CSS for missing rows
+    style_additions = """
+        .missing {
+            background-color: #fff3cd;
+            color: #856404;
+            font-style: italic;
+        }
+        .row-separator {
+            background-color: #e9ecef;
+            font-weight: bold;
+            text-align: center;
+            padding: 8px;
+            color: #495057;
+        }
+        .row-divider {
+            height: 20px;
+            background-color: #f8f9fa;
+            border-top: 1px solid #dee2e6;
+            border-bottom: 1px solid #dee2e6;
+        }
+        .row-subseparator {
+            background-color: #f1f3f5;
+            font-weight: bold;
+            text-align: center;
+            padding: 6px;
+            color: #666;
+            font-size: 0.9em;
+        }
+    """
+
+    # Insert the new styles before the closing </style> tag
+    html_content = html_content.replace("</style>", f"{style_additions}</style>")
+
+    html_content += """
+            </div>
+        </body>
+        </html>
+    """
+
+    output_file = diff_file.replace(".json", ".html")
+
+    try:
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write(html_content)
+        util.message(
+            f"HTML report generated: {util.set_colour(output_file, 'blue')}",
+            p_state="info"
+        )
+    except Exception as e:
+        util.exit_message(f"Error generating HTML report: {str(e)}")
+
+    return output_file


### PR DESCRIPTION
Adds a feature to report table diffs in html format. Usage `--output=html` while invoking `table-diff`