### PR TITLE
Add bidirectional insert

### DIFF
--- a/cli/scripts/ace-tests/conftest.py
+++ b/cli/scripts/ace-tests/conftest.py
@@ -1,9 +1,9 @@
 # flake8: disable=unused-import
 
-import concurrent.futures
 import importlib.util
 import os
 import sys
+from time import sleep
 import pytest
 import psycopg
 import test_config
@@ -105,7 +105,7 @@ def diff_file_path():
 
 
 @pytest.fixture(scope="session")
-def prepare_databases(ace_conf, nodes):
+def prepare_databases(nodes):
     """Setup fixture that prepares all databases before running tests"""
 
     def prepare_node(node):
@@ -128,6 +128,27 @@ def prepare_databases(ace_conf, nodes):
         );
         """
 
+        datatypes_sql = """
+        CREATE TABLE datatypes_test (
+            id UUID PRIMARY KEY,
+            int_col INTEGER,
+            float_col DOUBLE PRECISION,
+            array_col INTEGER[],
+            json_col JSONB,
+            bytea_col BYTEA,
+            point_col POINT,
+            text_col TEXT,
+            text_array_col TEXT[]
+        );
+        """
+
+        node_create_sql = f"""
+        SELECT spock.node_create('{node}', 'host={node} user=test dbname=demo')
+        """
+        repset_create_sql = """
+        SELECT spock.repset_create('test_repset')
+        """
+
         try:
             params = {
                 "host": node if node != "n1" else "localhost",
@@ -135,29 +156,61 @@ def prepare_databases(ace_conf, nodes):
                 "user": "admin",
                 "application_name": "ace-tests",
             }
-            if ace_conf.USE_CERT_AUTH:
-                params["sslmode"] = "verify-full"
-                params["sslrootcert"] = ace_conf.CA_CERT_FILE
-                params["sslcert"] = ace_conf.ADMIN_CERT_FILE
-                params["sslkey"] = ace_conf.ADMIN_KEY_FILE
 
             conn = psycopg.connect(**params)
-
-            # TODO: Find a way to assert that the connection is using SSL
-            if ace_conf.USE_CERT_AUTH:
-                pass
-
             cur = conn.cursor()
 
             # Creating the tables first
             cur.execute(customers_sql)
+            cur.execute(datatypes_sql)
 
-            # Loading the data
+            cur.execute(
+                """
+                INSERT INTO datatypes_test VALUES
+                (
+                    'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+                    42,
+                    3.14159,
+                    ARRAY[1, 2, 3, 4, 5],
+                    '{"key": "value", "nested": {"foo": "bar"}}',
+                    decode('DEADBEEF', 'hex'),
+                    point(1.5, 2.5),
+                    'sample text',
+                    ARRAY['apple', 'banana', 'cherry']
+                ),
+                (
+                    'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
+                    100,
+                    2.71828,
+                    ARRAY[10, 20, 30],
+                    '{"numbers": [1, 2, 3], "active": true}',
+                    decode('BADDCAFE', 'hex'),
+                    point(3.7, 4.2),
+                    'another sample',
+                    ARRAY['dog', 'cat', 'bird']
+                ),
+                (
+                    'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13',
+                    -17,
+                    0.577216,
+                    ARRAY[]::INTEGER[],
+                    '{"empty": true}',
+                    NULL,
+                    point(0, 0),
+                    'third sample',
+                    ARRAY[]::TEXT[]
+                )
+            """
+            )
+
             with open(test_config.CUSTOMERS_CSV, "r") as f:
                 with cur.copy(
                     "COPY customers FROM STDIN CSV HEADER DELIMITER ','"
                 ) as copy:
                     copy.write(f.read())
+
+            cur.execute(node_create_sql)
+            cur.execute(repset_create_sql)
 
             conn.commit()
 
@@ -172,29 +225,154 @@ def prepare_databases(ace_conf, nodes):
             print(f"Error executing SQL on node {node}: {str(e)}")
             return False
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(nodes)) as executor:
-        results = list(executor.map(prepare_node, nodes))
+    for node in nodes:
+        prepare_node(node)
 
-    # If database setup fails, we should fail the entire test suite
-    if not all(results):
-        pytest.fail("Database preparation failed")
+    def prepare_spock(node):
+        sub_sql = """
+        SELECT
+        spock.sub_create
+        ('sub_{provider_node}{node}', 'host={provider_node} user=test dbname=demo')
+        """
 
-    # Return the nodes for use in tests
-    return nodes
+        sub_add_sql = """
+        SELECT spock.sub_add_repset('sub_{provider_node}{node}', 'test_repset')
+        """
+
+        repset_add_customers_sql = """
+        SELECT spock.repset_add_table('test_repset', 'customers')
+        """
+
+        repset_add_datatypes_sql = """
+        SELECT spock.repset_add_table('test_repset', 'datatypes_test')
+        """
+
+        try:
+            params = {
+                "host": node if node != "n1" else "localhost",
+                "dbname": "demo",
+                "user": "admin",
+                "application_name": "ace-tests",
+            }
+
+            conn = psycopg.connect(**params)
+            cur = conn.cursor()
+
+            for provider_node in nodes:
+                if node != provider_node:
+                    cur.execute(sub_sql.format(provider_node=provider_node, node=node))
+                    cur.execute(
+                        sub_add_sql.format(provider_node=provider_node, node=node)
+                    )
+
+            cur.execute(repset_add_customers_sql)
+            cur.execute(repset_add_datatypes_sql)
+
+            conn.commit()
+
+            print(f"Successfully prepared Spock on node {node}")
+
+            cur.close()
+            conn.close()
+            return True
+        except Exception as e:
+            print(f"Error preparing Spock on node {node}: {str(e)}")
+            return False
+
+    for node in nodes:
+        prepare_spock(node)
+
+    sleep(5)
 
 
 @pytest.fixture(scope="session", autouse=True)
-def cleanup_databases(ace_conf, prepare_databases):
+def cleanup_databases(nodes):
     """Cleanup all databases after running tests"""
+
     # Yield to let the tests run first
     yield
 
     # Cleanup code that runs after all tests complete
     drop_customers_sql = "DROP TABLE IF EXISTS customers CASCADE;"
+    drop_datatypes_sql = "DROP TABLE IF EXISTS datatypes_test CASCADE;"
 
-    # prepare_databases returns the nodes list
-    nodes = prepare_databases
+    repset_remove_customers = """
+    SELECT spock.repset_remove_table('test_repset', 'customers')
+    """
 
+    repset_remove_datatypes = """
+    SELECT spock.repset_remove_table('test_repset', 'datatypes_test')
+    """
+
+    sub_remove_sql = """
+    SELECT spock.sub_remove_repset('sub_{provider_node}{node}', 'test_repset')
+    """
+
+    sub_drop_sql = """
+    SELECT spock.sub_drop('sub_{provider_node}{node}')
+    """
+
+    repset_drop_sql = """
+    SELECT spock.repset_drop('test_repset')
+    """
+
+    node_drop_sql = """
+    SELECT spock.node_drop('{node}')
+    """
+
+    for node in nodes:
+        other_nodes = [n for n in nodes if n != node]
+        try:
+            params = {
+                "host": node if node != "n1" else "localhost",
+                "dbname": "demo",
+                "user": "admin",
+                "application_name": "ace-tests",
+            }
+
+            conn = psycopg.connect(**params)
+            cur = conn.cursor()
+
+            cur.execute(repset_remove_customers)
+            print("remove customers from test_repset", cur.fetchone())
+            cur.execute(repset_remove_datatypes)
+            print("remove datatypes from test_repset", cur.fetchone())
+
+            for provider_node in other_nodes:
+                cur.execute(
+                    sub_remove_sql.format(provider_node=provider_node, node=node)
+                )
+                print(
+                    "remove subscription for",
+                    provider_node,
+                    "on",
+                    node,
+                    cur.fetchone(),
+                )
+                cur.execute(sub_drop_sql.format(provider_node=provider_node, node=node))
+                print(
+                    "drop subscription for",
+                    provider_node,
+                    "on",
+                    node,
+                    cur.fetchone(),
+                )
+
+            cur.execute(repset_drop_sql)
+            print("drop repset", cur.fetchone())
+
+            cur.execute(drop_customers_sql)
+            print("drop customers", cur.statusmessage)
+            cur.execute(drop_datatypes_sql)
+            print("drop datatypes", cur.statusmessage)
+
+            conn.commit()
+            cur.close()
+            conn.close()
+        except Exception as e:
+            print(f"Failed to cleanup node {node}: {str(e)}")
+
+    # We need to drop nodes *after* we've dropped subs and repsets
     for node in nodes:
         try:
             params = {
@@ -203,20 +381,11 @@ def cleanup_databases(ace_conf, prepare_databases):
                 "user": "admin",
                 "application_name": "ace-tests",
             }
-            if ace_conf.USE_CERT_AUTH:
-                params["sslmode"] = "verify-full"
-                params["sslrootcert"] = ace_conf.CA_CERT_FILE
-                params["sslcert"] = ace_conf.ADMIN_CERT_FILE
-                params["sslkey"] = ace_conf.ADMIN_KEY_FILE
 
             conn = psycopg.connect(**params)
-
-            # TODO: Find a way to assert that the connection is using SSL
-            if ace_conf.USE_CERT_AUTH:
-                pass
-
             cur = conn.cursor()
-            cur.execute(drop_customers_sql)
+            cur.execute(node_drop_sql.format(node=node))
+            print("drop node", cur.fetchone())
             conn.commit()
             cur.close()
             conn.close()

--- a/cli/scripts/ace-tests/test_api.py
+++ b/cli/scripts/ace-tests/test_api.py
@@ -16,7 +16,7 @@ class TestAPI(TestSimpleBase):
         daemon_thread = threading.Thread(target=ace_daemon.start_ace)
         daemon_thread.daemon = True  # Set as daemon so it exits when main thread exits
         daemon_thread.start()
-        time.sleep(2)  # Give the daemon time to start
+        time.sleep(2)
 
     def _get_api_base_url(self):
         return "https://localhost:5000/ace"

--- a/cli/scripts/ace-tests/test_data_types.py
+++ b/cli/scripts/ace-tests/test_data_types.py
@@ -5,94 +5,9 @@ import re
 from test_simple import TestSimple
 
 
-@pytest.mark.usefixtures("prepare_databases", "setup_datatypes")
+@pytest.mark.usefixtures("prepare_databases")
 class TestDataTypes(TestSimple):
     """Group of tests for various PostgreSQL data types"""
-
-    @pytest.fixture(scope="class", autouse=True)
-    def setup_datatypes(self, nodes):
-        """Setup fixture to create and populate a table with various data types"""
-        try:
-            # Create table with various data types on all nodes
-            for node in nodes:
-                print(f"Setting up datatypes test table on node {node}")
-                conn = psycopg.connect(host=node, dbname="demo", user="admin")
-                cur = conn.cursor()
-
-                # Create the table with various data types
-                cur.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS datatypes_test (
-                        id UUID PRIMARY KEY,
-                        int_col INTEGER,
-                        float_col DOUBLE PRECISION,
-                        array_col INTEGER[],
-                        json_col JSONB,
-                        bytea_col BYTEA,
-                        point_col POINT,
-                        text_col TEXT,
-                        text_array_col TEXT[]
-                    )
-                """
-                )
-
-                # Insert sample data
-                cur.execute(
-                    """
-                    INSERT INTO datatypes_test VALUES
-                    (
-                        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
-                        42,
-                        3.14159,
-                        ARRAY[1, 2, 3, 4, 5],
-                        '{"key": "value", "nested": {"foo": "bar"}}',
-                        decode('DEADBEEF', 'hex'),
-                        point(1.5, 2.5),
-                        'sample text',
-                        ARRAY['apple', 'banana', 'cherry']
-                    ),
-                    (
-                        'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
-                        100,
-                        2.71828,
-                        ARRAY[10, 20, 30],
-                        '{"numbers": [1, 2, 3], "active": true}',
-                        decode('BADDCAFE', 'hex'),
-                        point(3.7, 4.2),
-                        'another sample',
-                        ARRAY['dog', 'cat', 'bird']
-                    ),
-                    (
-                        'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13',
-                        -17,
-                        0.577216,
-                        ARRAY[]::INTEGER[],
-                        '{"empty": true}',
-                        NULL,
-                        point(0, 0),
-                        'third sample',
-                        ARRAY[]::TEXT[]
-                    )
-                """
-                )
-
-                conn.commit()
-                cur.close()
-                conn.close()
-
-            yield  # Let the tests run
-
-            # Cleanup: drop the test table
-            for node in nodes:
-                conn = psycopg.connect(host=node, dbname="demo", user="admin")
-                cur = conn.cursor()
-                cur.execute("DROP TABLE IF EXISTS datatypes_test")
-                conn.commit()
-                cur.close()
-                conn.close()
-
-        except Exception as e:
-            pytest.fail(f"Failed to setup/cleanup datatypes test: {str(e)}")
 
     # Override the table_name parameter for all parameterized tests
     @pytest.mark.parametrize("table_name", ["public.datatypes_test"])

--- a/cli/scripts/ace-tests/test_fix_nulls.py
+++ b/cli/scripts/ace-tests/test_fix_nulls.py
@@ -47,6 +47,12 @@ class TestTableRepairFixNulls:
                     """
                     )
 
+                repset_add_nulls_sql = """
+                SELECT spock.repset_add_table('test_repset', 'simple_nulls')
+                """
+                cur.execute(repset_add_nulls_sql)
+                print("add nulls to test_repset", cur.fetchone())
+
                 conn.commit()
                 cur.close()
                 conn.close()
@@ -57,7 +63,12 @@ class TestTableRepairFixNulls:
             for node in nodes:
                 conn = psycopg.connect(host=node, dbname="demo", user="admin")
                 cur = conn.cursor()
-                cur.execute("DROP TABLE IF EXISTS simple_nulls")
+                repset_remove_nulls = """
+                SELECT spock.repset_remove_table('test_repset', 'simple_nulls')
+                """
+                cur.execute(repset_remove_nulls)
+                print("remove nulls from test_repset", cur.fetchone())
+                cur.execute("DROP TABLE IF EXISTS simple_nulls CASCADE")
                 conn.commit()
                 cur.close()
                 conn.close()
@@ -116,6 +127,12 @@ class TestTableRepairFixNulls:
                     """
                     )
 
+                repset_add_nulls_sql = """
+                SELECT spock.repset_add_table('test_repset', 'composite_nulls')
+                """
+                cur.execute(repset_add_nulls_sql)
+                print("add nulls to test_repset", cur.fetchone())
+
                 conn.commit()
                 cur.close()
                 conn.close()
@@ -126,7 +143,12 @@ class TestTableRepairFixNulls:
             for node in nodes:
                 conn = psycopg.connect(host=node, dbname="demo", user="admin")
                 cur = conn.cursor()
-                cur.execute("DROP TABLE IF EXISTS composite_nulls")
+                repset_remove_nulls = """
+                SELECT spock.repset_remove_table('test_repset', 'composite_nulls')
+                """
+                cur.execute(repset_remove_nulls)
+                print("remove nulls from test_repset", cur.fetchone())
+                cur.execute("DROP TABLE IF EXISTS composite_nulls CASCADE")
                 conn.commit()
                 cur.close()
                 conn.close()
@@ -174,6 +196,12 @@ class TestTableRepairFixNulls:
                     """
                     )
 
+                repset_add_nulls_sql = """
+                SELECT spock.repset_add_table('test_repset', '"MixedCaseNulls"')
+                """
+                cur.execute(repset_add_nulls_sql)
+                print("add nulls to test_repset", cur.fetchone())
+
                 conn.commit()
                 cur.close()
                 conn.close()
@@ -184,7 +212,12 @@ class TestTableRepairFixNulls:
             for node in nodes:
                 conn = psycopg.connect(host=node, dbname="demo", user="admin")
                 cur = conn.cursor()
-                cur.execute('DROP TABLE IF EXISTS "MixedCaseNulls"')
+                repset_remove_nulls = """
+                SELECT spock.repset_remove_table('test_repset', '"MixedCaseNulls"')
+                """
+                cur.execute(repset_remove_nulls)
+                print("remove nulls from test_repset", cur.fetchone())
+                cur.execute('DROP TABLE IF EXISTS "MixedCaseNulls" CASCADE')
                 conn.commit()
                 cur.close()
                 conn.close()
@@ -241,6 +274,12 @@ class TestTableRepairFixNulls:
                     """
                     )
 
+                repset_add_nulls_sql = """
+                SELECT spock.repset_add_table('test_repset', 'datatype_nulls')
+                """
+                cur.execute(repset_add_nulls_sql)
+                print("add nulls to test_repset", cur.fetchone())
+
                 conn.commit()
                 cur.close()
                 conn.close()
@@ -251,7 +290,12 @@ class TestTableRepairFixNulls:
             for node in nodes:
                 conn = psycopg.connect(host=node, dbname="demo", user="admin")
                 cur = conn.cursor()
-                cur.execute("DROP TABLE IF EXISTS datatype_nulls")
+                repset_remove_nulls = """
+                SELECT spock.repset_remove_table('test_repset', 'datatype_nulls')
+                """
+                cur.execute(repset_remove_nulls)
+                print("remove nulls from test_repset", cur.fetchone())
+                cur.execute("DROP TABLE IF EXISTS datatype_nulls CASCADE")
                 conn.commit()
                 cur.close()
                 conn.close()

--- a/cli/scripts/ace-tests/test_insert_only.py
+++ b/cli/scripts/ace-tests/test_insert_only.py
@@ -1,0 +1,483 @@
+import pytest
+import psycopg
+import re
+
+
+@pytest.mark.usefixtures("prepare_databases")
+class TestInsertOnly:
+    """Tests for table-repair --insert-only feature"""
+
+    @pytest.fixture(scope="class")
+    def setup_test_scenario(self, nodes):
+        """Setup fixture to create different scenarios for insert-only testing"""
+        try:
+            for node in nodes:
+                conn = psycopg.connect(host=node, dbname="demo", user="admin")
+                cur = conn.cursor()
+
+                cur.execute(
+                    """
+                    CREATE TABLE insert_only_test (
+                        id INTEGER PRIMARY KEY,
+                        name TEXT,
+                        value INTEGER,
+                        created_at TIMESTAMP WITHOUT TIME ZONE
+                    )
+                """
+                )
+
+                if node == "n1":
+                    cur.execute(
+                        """
+                        INSERT INTO insert_only_test VALUES
+                        (1, 'Original 1', 100, '2024-01-01'),
+                        (2, 'Original 2', 200, '2024-01-02'),
+                        (3, 'Original 3', 300, '2024-01-03')
+                    """
+                    )
+                elif node == "n2":
+                    cur.execute(
+                        """
+                        INSERT INTO insert_only_test VALUES
+                        (1, 'Modified 1', 150, '2024-01-01'),
+                        (3, 'Modified 3', 350, '2024-01-03')
+                    """
+                    )
+                else:
+                    cur.execute(
+                        """
+                        INSERT INTO insert_only_test VALUES
+                        (1, 'Different 1', 175, '2024-01-01')
+                    """
+                    )
+
+                repset_sql = """
+                    SELECT spock.repset_add_table('test_repset', 'insert_only_test')
+                """
+                cur.execute(repset_sql)
+
+                conn.commit()
+                cur.close()
+                conn.close()
+
+            yield
+
+            for node in nodes:
+                conn = psycopg.connect(host=node, dbname="demo", user="admin")
+                cur = conn.cursor()
+
+                cur.execute(
+                    """
+                    SELECT spock.repset_remove_table('test_repset', 'insert_only_test')
+                """
+                )
+
+                cur.execute("DROP TABLE IF EXISTS insert_only_test CASCADE")
+
+                conn.commit()
+                cur.close()
+                conn.close()
+
+        except Exception as e:
+            pytest.fail(f"Failed to setup/cleanup insert only test: {str(e)}")
+
+    @pytest.mark.usefixtures("setup_test_scenario")
+    def test_insert_only_repair(self, cli, capsys):
+        """
+        Test that insert-only repair only adds missing rows without
+        modifying existing ones
+        """
+        try:
+            cli.table_diff_cli("eqn-t9da", "public.insert_only_test")
+            captured = capsys.readouterr()
+            clean_output = re.sub(
+                r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", captured.out
+            )
+            match = re.search(r"diffs written out to (.+\.json)", clean_output.lower())
+            assert match, "Diff file path not found in output"
+            diff_file = match.group(1)
+
+            cli.table_repair_cli(
+                "eqn-t9da",
+                "public.insert_only_test",
+                diff_file,
+                source_of_truth="n1",
+                insert_only=True,
+            )
+
+            conn = psycopg.connect(host="n2", dbname="demo", user="admin")
+            cur = conn.cursor()
+            cur.execute("SELECT * FROM insert_only_test ORDER BY id")
+            n2_rows = cur.fetchall()
+            cur.close()
+            conn.close()
+
+            # Verify that on n2:
+            # 1. Missing row (id=2) was inserted
+            # 2. Existing rows (id=1,3) were not modified
+            assert len(n2_rows) == 3, "Expected 3 rows after repair"
+
+            assert n2_rows[0][1] == "Modified 1", "Row 1 should not be modified"
+            assert n2_rows[0][2] == 150, "Row 1 value should not be modified"
+
+            assert n2_rows[2][1] == "Modified 3", "Row 3 should not be modified"
+            assert n2_rows[2][2] == 350, "Row 3 value should not be modified"
+
+            assert n2_rows[1][0] == 2, "Missing row should be inserted"
+            assert (
+                n2_rows[1][1] == "Original 2"
+            ), "Missing row should have original name"
+            assert n2_rows[1][2] == 200, "Missing row should have original value"
+
+            conn = psycopg.connect(host="n3", dbname="demo", user="admin")
+            cur = conn.cursor()
+            cur.execute("SELECT * FROM insert_only_test ORDER BY id")
+            n3_rows = cur.fetchall()
+            cur.close()
+            conn.close()
+
+            # Verify that on n3:
+            # 1. Missing rows (id=2,3) were inserted
+            # 2. Existing row (id=1) was not modified
+            assert len(n3_rows) == 3, "Expected 3 rows after repair"
+
+            assert n3_rows[0][1] == "Different 1", "Row 1 should not be modified"
+            assert n3_rows[0][2] == 175, "Row 1 value should not be modified"
+
+            assert n3_rows[1][0] == 2, "Missing row 2 should be inserted"
+            assert n3_rows[1][1] == "Original 2", "Row 2 should have original name"
+            assert n3_rows[1][2] == 200, "Row 2 should have original value"
+
+            assert n3_rows[2][0] == 3, "Missing row 3 should be inserted"
+            assert n3_rows[2][1] == "Original 3", "Row 3 should have original name"
+            assert n3_rows[2][2] == 300, "Row 3 should have original value"
+
+        except Exception as e:
+            pytest.fail(f"Test failed: {str(e)}")
+
+    @pytest.mark.usefixtures("setup_test_scenario")
+    def test_insert_only_with_deletes(self, cli, capsys):
+        """Test that insert-only repair ignores deletes"""
+        try:
+            # Let's delete a row on n1 and check that it's not deleted on n2
+            conn = psycopg.connect(host="n1", dbname="demo", user="admin")
+            cur = conn.cursor()
+            cur.execute("SELECT spock.repair_mode(true)")
+            cur.execute("DELETE FROM insert_only_test WHERE id = 1")
+            conn.commit()
+            cur.close()
+            conn.close()
+
+            cli.table_diff_cli("eqn-t9da", "public.insert_only_test")
+            captured = capsys.readouterr()
+            clean_output = re.sub(
+                r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", captured.out
+            )
+            match = re.search(r"diffs written out to (.+\.json)", clean_output.lower())
+            assert match, "Diff file path not found in output"
+            diff_file = match.group(1)
+
+            cli.table_repair_cli(
+                "eqn-t9da",
+                "public.insert_only_test",
+                diff_file,
+                source_of_truth="n1",
+                insert_only=True,
+            )
+
+            # Verify that row 1 still exists on n2 and n3
+            for node in ["n2", "n3"]:
+                conn = psycopg.connect(host=node, dbname="demo", user="admin")
+                cur = conn.cursor()
+                cur.execute("SELECT COUNT(*) FROM insert_only_test WHERE id = 1")
+                count = cur.fetchone()[0]
+                cur.close()
+                conn.close()
+
+                assert count == 1, f"Row 1 should still exist on {node}"
+
+        except Exception as e:
+            pytest.fail(f"Test failed: {str(e)}")
+
+    @pytest.fixture(scope="class")
+    def setup_bidirectional_scenario(self, nodes):
+        """Setup fixture to create scenarios for bidirectional insert testing"""
+        try:
+            for node in nodes:
+                conn = psycopg.connect(host=node, dbname="demo", user="admin")
+                cur = conn.cursor()
+
+                cur.execute(
+                    """
+                    CREATE TABLE bidirectional_test (
+                        id INTEGER PRIMARY KEY,
+                        name TEXT,
+                        value INTEGER,
+                        created_at TIMESTAMP WITHOUT TIME ZONE
+                    )
+                """
+                )
+                print(f"Created table bidirectional_test on {node}")
+
+                if node == "n1":
+                    cur.execute(
+                        """
+                        INSERT INTO bidirectional_test
+                        SELECT
+                            generate_series(1, 10) as id,
+                            'n1_row_' || generate_series(1, 10) as name,
+                            generate_series(1, 10) * 100 as value,
+                            now() as created_at
+                    """
+                    )
+                elif node == "n2":
+                    cur.execute(
+                        """
+                        INSERT INTO bidirectional_test
+                        SELECT
+                            id,
+                            'n2_row_' || id as name,
+                            id * 100 as value,
+                            now() as created_at
+                        FROM (
+                            SELECT generate_series(11, 15) as id
+                        ) t
+                    """
+                    )
+                else:
+                    cur.execute(
+                        """
+                        INSERT INTO bidirectional_test
+                        SELECT
+                            id,
+                            'n3_row_' || id as name,
+                            id * 100 as value,
+                            now() as created_at
+                        FROM (
+                            SELECT generate_series(16, 20) as id
+                        ) t
+                    """
+                    )
+                print(f"Inserted data into bidirectional_test on {node}")
+
+                repset_sql = """
+                    SELECT spock.repset_add_table('test_repset', 'bidirectional_test')
+                """
+                cur.execute(repset_sql)
+                print(f"Added table to replication set on {node}")
+                conn.commit()
+                cur.close()
+                conn.close()
+
+            yield
+
+            for node in nodes:
+                conn = psycopg.connect(host=node, dbname="demo", user="admin")
+                cur = conn.cursor()
+
+                cur.execute(
+                    """
+                    SELECT
+                    spock.repset_remove_table('test_repset', 'bidirectional_test')
+                    """
+                )
+
+                cur.execute("DROP TABLE IF EXISTS bidirectional_test CASCADE")
+
+                conn.commit()
+                cur.close()
+                conn.close()
+
+        except Exception as e:
+            pytest.fail(f"Failed to setup/cleanup bidirectional test: {str(e)}")
+
+    @pytest.mark.usefixtures("setup_bidirectional_scenario")
+    def test_bidirectional_insert(self, cli, capsys):
+        """Test that bidirectional insert propagates missing rows in both directions"""
+        try:
+            print("Running table-diff on bidirectional_test")
+            cli.table_diff_cli("eqn-t9da", "public.bidirectional_test")
+            captured = capsys.readouterr()
+            clean_output = re.sub(
+                r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", captured.out
+            )
+            match = re.search(r"diffs written out to (.+\.json)", clean_output.lower())
+            assert match, "Diff file path not found in output"
+            diff_file = match.group(1)
+
+            print("Running table-repair on bidirectional_test")
+            cli.table_repair_cli(
+                "eqn-t9da",
+                "public.bidirectional_test",
+                diff_file,
+                insert_only=True,
+                bidirectional=True,
+            )
+            captured = capsys.readouterr()
+            clean_output = re.sub(
+                r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", captured.out
+            )
+            assert (
+                "completed bidirectional repair" in clean_output.lower()
+            ), "Bidirectional repair failed"
+
+            # Verify results on each node
+            for node in ["n1", "n2", "n3"]:
+                print(f"\nVerifying data on node {node}")
+                try:
+                    conn = psycopg.connect(
+                        host=node,
+                        dbname="demo",
+                        user="admin",
+                        connect_timeout=10,  # Add connection timeout
+                    )
+                    cur = conn.cursor()
+
+                    print(f"Checking total row count on {node}")
+                    cur.execute("SELECT COUNT(*) FROM bidirectional_test")
+                    count = cur.fetchone()[0]
+                    assert count == 20, f"Expected 20 rows on {node}, found {count}"
+                    print(f"Total row count on {node}: {count}")
+
+                    # Check n1's original rows (1-10)
+                    print(f"Checking n1's rows on {node}")
+                    cur.execute(
+                        """
+                        SELECT COUNT(*) FROM bidirectional_test
+                        WHERE id BETWEEN 1 AND 10
+                        AND name LIKE 'n1_row_%'
+                    """
+                    )
+                    n1_rows = cur.fetchone()[0]
+                    assert (
+                        n1_rows == 10
+                    ), f"Expected 10 n1 rows on {node}, found {n1_rows}"
+                    print(f"n1 row count on {node}: {n1_rows}")
+
+                    # Check n2's unique rows (11-15)
+                    print(f"Checking n2's rows on {node}")
+                    cur.execute(
+                        """
+                        SELECT COUNT(*) FROM bidirectional_test
+                        WHERE id BETWEEN 11 AND 15
+                        AND name LIKE 'n2_row_%'
+                    """
+                    )
+                    n2_rows = cur.fetchone()[0]
+                    assert (
+                        n2_rows == 5
+                    ), f"Expected 5 n2 rows on {node}, found {n2_rows}"
+                    print(f"n2 row count on {node}: {n2_rows}")
+
+                    # Check n3's unique rows (16-20)
+                    print(f"Checking n3's rows on {node}")
+                    cur.execute(
+                        """
+                        SELECT COUNT(*) FROM bidirectional_test
+                        WHERE id BETWEEN 16 AND 20
+                        AND name LIKE 'n3_row_%'
+                    """
+                    )
+                    n3_rows = cur.fetchone()[0]
+                    assert (
+                        n3_rows == 5
+                    ), f"Expected 5 n3 rows on {node}, found {n3_rows}"
+                    print(f"n3 row count on {node}: {n3_rows}")
+
+                    # Print full data for debugging if counts don't match
+                    if count != 20 or n1_rows != 10 or n2_rows != 5 or n3_rows != 5:
+                        print(f"\nDumping full data for {node}:")
+                        cur.execute(
+                            """
+                            SELECT id, name, value
+                            FROM bidirectional_test
+                            ORDER BY id
+                        """
+                        )
+                        rows = cur.fetchall()
+                        for row in rows:
+                            print(row)
+
+                except Exception as node_error:
+                    print(f"Error while checking node {node}: {str(node_error)}")
+                    raise
+
+                finally:
+                    if cur:
+                        cur.close()
+                    if conn:
+                        conn.close()
+                    print(f"Completed verification for node {node}")
+
+        except Exception as e:
+            print(f"Test failed with error: {str(e)}")
+            pytest.fail(f"Test failed: {str(e)}")
+
+    @pytest.mark.usefixtures("setup_bidirectional_scenario")
+    def test_bidirectional_insert_with_updates(self, cli, capsys):
+        """Test that bidirectional insert ignores updates even with conflicts"""
+        try:
+            for node, suffix in [("n2", "_n2_modified"), ("n3", "_n3_modified")]:
+                conn = psycopg.connect(host=node, dbname="demo", user="admin")
+                cur = conn.cursor()
+                cur.execute("SELECT spock.repair_mode(true)")
+                # Modify rows 1-5 which exist on all nodes
+                cur.execute(
+                    f"""
+                    UPDATE bidirectional_test
+                    SET name = name || '{suffix}',
+                        value = value + 1000
+                    WHERE id BETWEEN 1 AND 5
+                """
+                )
+                conn.commit()
+                cur.close()
+                conn.close()
+
+            cli.table_diff_cli("eqn-t9da", "public.bidirectional_test")
+            captured = capsys.readouterr()
+            clean_output = re.sub(
+                r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", captured.out
+            )
+            match = re.search(r"diffs written out to (.+\.json)", clean_output.lower())
+            assert match, "Diff file path not found in output"
+            diff_file = match.group(1)
+
+            cli.table_repair_cli(
+                "eqn-t9da",
+                "public.bidirectional_test",
+                diff_file,
+                insert_only=True,
+                bidirectional=True,
+            )
+
+            # Verify that modifications remain unchanged
+            for node, suffix in [("n2", "_n2_modified"), ("n3", "_n3_modified")]:
+                conn = psycopg.connect(host=node, dbname="demo", user="admin")
+                cur = conn.cursor()
+
+                cur.execute(
+                    f"""
+                    SELECT COUNT(*) FROM bidirectional_test
+                    WHERE id BETWEEN 1 AND 5
+                    AND name LIKE '%{suffix}'
+                    AND value > 1000
+                """
+                )
+                modified_count = cur.fetchone()[0]
+                assert (
+                    modified_count == 5
+                ), f"Modified rows should remain unchanged on {node}"
+
+                # But all 20 rows should exist
+                cur.execute("SELECT COUNT(*) FROM bidirectional_test")
+                total_count = cur.fetchone()[0]
+                assert (
+                    total_count == 20
+                ), f"Expected 20 total rows on {node}, found {total_count}"
+
+                cur.close()
+                conn.close()
+
+        except Exception as e:
+            pytest.fail(f"Test failed: {str(e)}")

--- a/cli/scripts/ace-tests/test_replication.py
+++ b/cli/scripts/ace-tests/test_replication.py
@@ -11,20 +11,6 @@ class TestReplication:
     """Group of tests for various PostgreSQL data types"""
 
     test_data = {
-        "public.datatypes_test": {
-            "key_column": "id",
-            "row": {
-                "id": "d0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14",
-                "int_col": 999,
-                "float_col": 9.99,
-                "array_col": [9, 9, 9],
-                "json_col": {"test": "value"},
-                "bytea_col": b"test",
-                "point_col": "(9.9,9.9)",
-                "text_col": "test replication",
-                "text_array_col": ["test", "array"],
-            },
-        },
         "public.customers": {
             "key_column": "index",
             "row": {
@@ -44,9 +30,7 @@ class TestReplication:
         },
     }
 
-    @pytest.mark.parametrize(
-        "table_name", ["public.datatypes_test", "public.customers"]
-    )
+    @pytest.mark.parametrize("table_name", ["public.customers"])
     def test_replication(
         self,
         cli,

--- a/cli/scripts/ace-tests/test_replication.py
+++ b/cli/scripts/ace-tests/test_replication.py
@@ -1,0 +1,119 @@
+import pytest
+import psycopg
+import json
+import re
+import time
+from datetime import datetime
+
+
+@pytest.mark.usefixtures("prepare_databases")
+class TestReplication:
+    """Group of tests for various PostgreSQL data types"""
+
+    test_data = {
+        "public.datatypes_test": {
+            "key_column": "id",
+            "row": {
+                "id": "d0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14",
+                "int_col": 999,
+                "float_col": 9.99,
+                "array_col": [9, 9, 9],
+                "json_col": {"test": "value"},
+                "bytea_col": b"test",
+                "point_col": "(9.9,9.9)",
+                "text_col": "test replication",
+                "text_array_col": ["test", "array"],
+            },
+        },
+        "public.customers": {
+            "key_column": "index",
+            "row": {
+                "index": 10001,
+                "customer_id": "TEST001",
+                "first_name": "Test",
+                "last_name": "User",
+                "company": "Test Company",
+                "city": "Test City",
+                "country": "Test Country",
+                "phone_1": "123-456-7890",
+                "phone_2": "098-765-4321",
+                "email": "test@example.com",
+                "subscription_date": datetime.now(),
+                "website": "www.test.com",
+            },
+        },
+    }
+
+    @pytest.mark.parametrize(
+        "table_name", ["public.datatypes_test", "public.customers"]
+    )
+    def test_replication(
+        self,
+        cli,
+        capsys,
+        table_name,
+    ):
+        """Test that a row inserted on one node gets replicated to others"""
+        try:
+            # Get test data for the current table
+            test_data = self.test_data[table_name]
+            test_row = test_data["row"]
+
+            # Insert a new row into n2
+            conn = psycopg.connect(host="n2", dbname="demo", user="admin")
+            cur = conn.cursor()
+
+            # Create the INSERT statement dynamically
+            columns = list(test_row.keys())
+            placeholders = ["%s"] * len(columns)
+            insert_sql = f"""
+                INSERT INTO {table_name} ({', '.join(columns)})
+                VALUES ({', '.join(placeholders)})
+            """
+
+            # Convert values for database insertion
+            values = []
+            for val in test_row.values():
+                if isinstance(val, dict):
+                    values.append(json.dumps(val))
+                elif isinstance(val, datetime):
+                    values.append(val.isoformat())
+                else:
+                    values.append(val)
+
+            cur.execute(insert_sql, values)
+            conn.commit()
+            cur.close()
+            conn.close()
+
+            # Give some time for replication to occur
+            time.sleep(2)
+
+            # Execute table diff and verify results
+            cli.table_diff_cli("eqn-t9da", table_name)
+
+            # Capture and verify output
+            captured = capsys.readouterr()
+            clean_output = re.sub(
+                r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", captured.out
+            )
+
+            # Verify no differences are found (replication worked)
+            assert (
+                "tables match ok" in clean_output.lower()
+            ), "Expected no differences after replication"
+
+            # Clean up - delete the test row
+            conn = psycopg.connect(host="n2", dbname="demo", user="admin")
+            cur = conn.cursor()
+            key_column = test_data["key_column"]
+            cur.execute(
+                f"DELETE FROM {table_name} WHERE {key_column} = %s",
+                (test_row[key_column],),
+            )
+            conn.commit()
+            cur.close()
+            conn.close()
+
+        except Exception as e:
+            pytest.fail(f"Test failed: {str(e)}")

--- a/cli/scripts/ace-tests/test_simple.py
+++ b/cli/scripts/ace-tests/test_simple.py
@@ -171,6 +171,7 @@ class TestSimple(TestSimpleBase):
                 pass
 
             cur = conn.cursor()
+            cur.execute("SELECT spock.repair_mode(true)")
             cur.execute(
                 f"""
                 UPDATE {schema}.\"{table}\"

--- a/cli/scripts/ace-tests/test_simple_base.py
+++ b/cli/scripts/ace-tests/test_simple_base.py
@@ -51,6 +51,7 @@ class TestSimpleBase(abc.ABC):
             pass
 
         cur = conn.cursor()
+        cur.execute("SELECT spock.repair_mode(true)")
 
         # Note: column_name should be quoted if it contains uppercase
         cur.execute(

--- a/cli/scripts/ace-tests/test_table_filter.py
+++ b/cli/scripts/ace-tests/test_table_filter.py
@@ -52,6 +52,7 @@ class TestTableFilter:
             # Introduce differences only within the filter range
             conn = psycopg.connect(host="n2", dbname="demo", user="admin")
             cur = conn.cursor()
+            cur.execute("SELECT spock.repair_mode(true)")
             cur.execute(
                 f"""
                 UPDATE customers
@@ -178,6 +179,7 @@ class TestTableFilter:
         try:
             conn = psycopg.connect(host="n2", dbname="demo", user="admin")
             cur = conn.cursor()
+            cur.execute("SELECT spock.repair_mode(true)")
             cur.execute(
                 """
                 UPDATE customers

--- a/cli/scripts/ace.py
+++ b/cli/scripts/ace.py
@@ -600,12 +600,7 @@ def convert_pg_type_to_json(item: str, type: str):
 
         type_lower = type.lower()
 
-        if (
-            not item
-            or item == ""
-            or item.lower() == "null"
-            or item.lower() == "none"
-        ):
+        if not item or item == "" or item.lower() == "null" or item.lower() == "none":
             return None
         elif "[]" in type_lower:
             return ast.literal_eval(item)
@@ -957,6 +952,9 @@ def validate_table_diff_inputs(td_task: TableDiffTask) -> None:
             continue
         combined_json = {**database, **node}
         cluster_nodes.append(combined_json)
+
+    if not node_list:
+        node_list = [node["name"] for node in cluster_nodes]
 
     if td_task._nodes == "all" and len(cluster_nodes) > 3:
         raise AceException("Table-diff only supports up to three way comparison")

--- a/cli/scripts/ace_cli.py
+++ b/cli/scripts/ace_cli.py
@@ -131,9 +131,11 @@ def table_repair_cli(
     dry_run=False,
     quiet=False,
     generate_report=False,
+    insert_only=False,
     upsert_only=False,
     fix_nulls=False,
     fire_triggers=False,
+    bidirectional=False,
 ):
 
     task_id = ace_db.generate_task_id()
@@ -148,9 +150,11 @@ def table_repair_cli(
             dry_run=dry_run,
             quiet_mode=quiet,
             generate_report=generate_report,
+            insert_only=insert_only,
             upsert_only=upsert_only,
             fix_nulls=fix_nulls,
             fire_triggers=fire_triggers,
+            bidirectional=bidirectional,
             invoke_method="cli",
         )
         tr_task.scheduler.task_id = task_id

--- a/cli/scripts/ace_cli.py
+++ b/cli/scripts/ace_cli.py
@@ -167,6 +167,8 @@ def table_repair_cli(
 
         if fix_nulls:
             ace_core.table_repair_fix_nulls(tr_task)
+        elif bidirectional:
+            ace_core.table_repair_bidirectional(tr_task)
         else:
             ace_core.table_repair(tr_task)
 

--- a/cli/scripts/ace_daemon.py
+++ b/cli/scripts/ace_daemon.py
@@ -218,6 +218,8 @@ def table_repair_api():
 
         if fix_nulls:
             scheduler.add_job(ace_core.table_repair_fix_nulls, args=(raw_args,))
+        elif bidirectional:
+            scheduler.add_job(ace_core.table_repair_bidirectional, args=(raw_args,))
         else:
             scheduler.add_job(ace_core.table_repair, args=(raw_args,))
 

--- a/cli/scripts/ace_daemon.py
+++ b/cli/scripts/ace_daemon.py
@@ -160,9 +160,11 @@ def table_repair_api():
     dry_run = data.get("dry_run", False)
     quiet = data.get("quiet", False)
     generate_report = data.get("generate_report", False)
+    insert_only = data.get("insert_only", False)
     upsert_only = data.get("upsert_only", False)
     fix_nulls = data.get("fix_nulls", False)
     fire_triggers = data.get("fire_triggers", False)
+    bidirectional = data.get("bidirectional", False)
 
     if not cluster_name or not diff_file or not table_name:
         return (
@@ -198,10 +200,12 @@ def table_repair_api():
             dry_run=dry_run,
             quiet_mode=quiet,
             generate_report=generate_report,
+            insert_only=insert_only,
             upsert_only=upsert_only,
-            invoke_method="api",
             fix_nulls=fix_nulls,
             fire_triggers=fire_triggers,
+            bidirectional=bidirectional,
+            invoke_method="api",
         )
         raw_args.scheduler.task_id = task_id
         raw_args.scheduler.task_type = "table-repair"
@@ -211,7 +215,11 @@ def table_repair_api():
 
         ace.validate_table_repair_inputs(raw_args)
         ace_db.create_ace_task(task=raw_args)
-        scheduler.add_job(ace_core.table_repair, args=(raw_args,))
+
+        if fix_nulls:
+            scheduler.add_job(ace_core.table_repair_fix_nulls, args=(raw_args,))
+        else:
+            scheduler.add_job(ace_core.table_repair, args=(raw_args,))
 
         return jsonify({"task_id": task_id, "submitted_at": datetime.now().isoformat()})
     except Exception as e:

--- a/cli/scripts/ace_data_models.py
+++ b/cli/scripts/ace_data_models.py
@@ -97,9 +97,12 @@ class TableRepairTask:
     quiet_mode: bool
     dry_run: bool
     generate_report: bool
+    insert_only: bool
     upsert_only: bool
     fix_nulls: bool
     fire_triggers: bool
+
+    bidirectional: bool
 
     invoke_method: str = "cli"
 

--- a/cli/scripts/ace_readme.md
+++ b/cli/scripts/ace_readme.md
@@ -133,7 +133,10 @@ In some special cases, you may want to use the `--fix-nulls` option to fix NULL 
 - `--quiet`: Suppress non-essential output
 - `--generate-report`: Create a detailed report of repair operations
 - `--upsert-only`: Only perform inserts/updates, skip deletions
-- `--insert-only`: Only perform inserts, skip updates and deletions
+- `--insert-only`: Only perform inserts, skip updates and deletions. Note: This
+  option uses `INSERT INTO ... ON CONFLICT DO NOTHING`. So, if there are
+  identical rows with different values, this option alone is not enough to fully
+  repair the table.
 - `--fix-nulls`: Fix NULL values by comparing across nodes (special use case)
 
 ### Examples

--- a/cli/scripts/ace_readme.md
+++ b/cli/scripts/ace_readme.md
@@ -133,6 +133,7 @@ In some special cases, you may want to use the `--fix-nulls` option to fix NULL 
 - `--quiet`: Suppress non-essential output
 - `--generate-report`: Create a detailed report of repair operations
 - `--upsert-only`: Only perform inserts/updates, skip deletions
+- `--insert-only`: Only perform inserts, skip updates and deletions
 - `--fix-nulls`: Fix NULL values by comparing across nodes (special use case)
 
 ### Examples
@@ -167,9 +168,12 @@ Conservative repair (updates only):
 
 ### Best Practices
 
-1. Ensure MAX_ALLOWED_DIFFS have not exceeded during table-diff. Otherwise, table-repair will only be able to partially repair the table.
+1. Table-repair can only repair rows found in the diff file. If `MAX_ALLOWED_DIFFS`
+is exceeded during table-diff, table-repair will only be able to partially repair the table.
+Sometimes, this may even be desirable if you want to repair the table in batches.
+You'd have to do a `diff->repair->diff->repair` cycle until no more differences are reported.
 2. Run with `--dry-run` first to review proposed changes
-3. Use `--upsert-only` for critical tables where data deletion may be risky
+3. Use `--upsert-only` or `--insert-only` for critical tables where data deletion may be risky
 4. Verify table structure and constraints before repair
 
 ### Common Use Cases


### PR DESCRIPTION
This PR adds the `--insert-only` and `--bidirectional` to table-repair. It allows for only insert repairs to happen--either from a source of truth node or in a bidirectional manner