### PR TITLE
Fixed issue where replica nodes weren't starting.

### DIFF
--- a/cli/scripts/ha_patroni.py
+++ b/cli/scripts/ha_patroni.py
@@ -66,12 +66,13 @@ bootstrap:
     loop_wait: 10
     retry_timeout: 10
     maximum_lag_on_failover: 1048576
-  postgresql:
-    use_pg_rewind: true
-    use_slots: true
-    parameters:
+    postgresql:
+      use_pg_rewind: true
+      use_slots: true
+      parameters:
         wal_keep_size: 64MB
         wal_keep_segments: 0
+        track_commit_timestamp: true
 
   pg_hba:
     - host replication replicator 0.0.0.0/0 trust


### PR DESCRIPTION
This was being caused by `track_commit_timestamps` not being enabled while `spock.conflict_resolution` was set to `last_update_wins`. Since this is such a fundamental configuration setting, I've placed it in the DCS `bootstrap` section of the Patroni config, so it's applied to all nodes.

This also required pushing the nesting of the `postgres` block down one level, as it's supposed to reside under `dcs` rather than `bootstrap`.