### PR TITLE
cleanup inputs / version / display in json-create

### DIFF
--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -1176,21 +1176,21 @@ def json_create(
     print(
         f"# {bold_start}Spock Version{bold_end}      : {spock_version if spock_version else 'Not specified'}"
     )
+    print(f"# {bold_start}Number of Nodes{bold_end}    : {num_nodes}")
+    print(f"# {bold_start}Database Name{bold_end}      : {db}")
+    print(f"# {bold_start}User{bold_end}               : {usr}")
     print(
         f"# {bold_start}pgBackRest Enabled{bold_end} : {'Yes' if backrest_enabled else 'No'}"
     )
     if backrest_enabled:
-        print(f"#      {bold_start}Storage Path{bold_end} : {backrest_storage_path}")
-        print(f"#      {bold_start}Archive Mode{bold_end} : {backrest_archive_mode}")
-        print(f"#      {bold_start}Repository Type{bold_end} : {repo1_type}")
-    print(f"# {bold_start}Number of Nodes{bold_end}    : {num_nodes}")
-    print(f"# {bold_start}Database Name{bold_end}      : {db}")
-    print(f"# {bold_start}User{bold_end}               : {usr}")
+        print(f"#    {bold_start}Storage Path{bold_end}    : {backrest_storage_path}")
+        print(f"#    {bold_start}Archive Mode{bold_end}    : {backrest_archive_mode}")
+        print(f"#    {bold_start}Repository Type{bold_end} : {repo1_type}")
     for idx, node in enumerate(node_groups, start=1):
         print(f"# {bold_start}Node {idx}{bold_end}")
-        print(f"#      {bold_start}Public IP{bold_end}     : {node['public_ip']}")
-        print(f"#      {bold_start}Private IP{bold_end}    : {node['private_ip']}")
-        print(f"#      {bold_start}Port{bold_end}          : {node['port']}")
+        print(f"#    {bold_start}Public IP{bold_end}       : {node['public_ip']}")
+        print(f"#    {bold_start}Private IP{bold_end}      : {node['private_ip']}")
+        print(f"#    {bold_start}Port{bold_end}            : {node['port']}")
     
     print("#" * 80)
 

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -845,7 +845,7 @@ def json_create(
                 pg_input = str(pg_version_int)
             else:
                 pg_input = (
-                    input(f"PostgreSQL version {pgs} (default: {pg_default}): ").strip()
+                    input(f"PostgreSQL version {pgs} (default: '{pg_default}'): ").strip()
                     or pg_default
                 )
 
@@ -864,7 +864,7 @@ def json_create(
         while True:
             spock_version = (
                 input(
-                    f"Spock version {spocks} (default: {spock_default}): "
+                    f"Spock version {spocks} (default: '{spock_default}'): "
                 ).strip()
                 or spock_default
             )
@@ -905,11 +905,11 @@ def json_create(
     # Initialize backrest_json based on user input
     if backrest_enabled:
         backrest_storage_path = (
-            input("   pgBackRest storage path (default: /var/lib/pgbackrest): ").strip()
+            input("   pgBackRest storage path (default: '/var/lib/pgbackrest'): ").strip()
             or "/var/lib/pgbackrest"
         )
         backrest_archive_mode = (
-            input("   pgBackRest archive mode (on/off) (default: on): ").strip().lower()
+            input("   pgBackRest archive mode (on/off) (default: 'on'): ").strip().lower()
             or "on"
         )
         if backrest_archive_mode not in ["on", "off"]:
@@ -918,7 +918,7 @@ def json_create(
             )
          # Optionally, ask for repo1_type or default to posix
         repo1_type = (
-            input("   pgBackRest repository type (posix/s3) (default: posix): ")
+            input("   pgBackRest repository type (posix/s3) (default: 'posix'): ")
             .strip()
             .lower()
             or "posix"

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -1180,9 +1180,9 @@ def json_create(
         f"# {bold_start}pgBackRest Enabled{bold_end} : {'Yes' if backrest_enabled else 'No'}"
     )
     if backrest_enabled:
-        print(f"# {bold_start}BackRest Storage Path{bold_end} : {backrest_storage_path}")
-        print(f"# {bold_start}BackRest Archive Mode{bold_end} : {backrest_archive_mode}")
-        print(f"# {bold_start}BackRest Repository Type{bold_end} : {repo1_type}")
+        print(f"#      {bold_start}Storage Path{bold_end} : {backrest_storage_path}")
+        print(f"#      {bold_start}Archive Mode{bold_end} : {backrest_archive_mode}")
+        print(f"#      {bold_start}Repository Type{bold_end} : {repo1_type}")
     print(f"# {bold_start}Number of Nodes{bold_end}    : {num_nodes}")
     print(f"# {bold_start}Database Name{bold_end}      : {db}")
     print(f"# {bold_start}User{bold_end}               : {usr}")

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -1171,27 +1171,27 @@ def json_create(
     bold_end = "\033[0m"
 
     print("\n" + "#" * 80)
-    print(
-        f"#     {bold_start}Version{bold_end}        : pgEdge 24.10-5 (Constellation)"
-    )
-    print(f"# {bold_start}User & Host{bold_end}        : {os_user}    {os.getcwd()}")
-    print(
-        f"#          {bold_start}OS{bold_end}        : Linux, Python {sys.version.split()[0]}"
-    )
-    print(f"#     {bold_start}Machine{bold_end}        : N/A")
-    print(f"#    {bold_start}Repo URL{bold_end}        : N/A")
-    print(f"# {bold_start}Last Update{bold_end}        : None")
     print(f"# {bold_start}Cluster Name{bold_end}       : {cluster_name}")
     print(f"# {bold_start}PostgreSQL Version{bold_end} : {pg_version_int}")
     print(
         f"# {bold_start}Spock Version{bold_end}      : {spock_version if spock_version else 'Not specified'}"
     )
-    # print(
-    #     f"# {bold_start}HA Cluster{bold_end}         : {'Yes' if is_ha_cluster else 'No'}"
-    # )
     print(
-        f"# {bold_start}pgBackRest Enabled{bold_end}   : {'Yes' if backrest_enabled else 'No'}"
+        f"# {bold_start}pgBackRest Enabled{bold_end} : {'Yes' if backrest_enabled else 'No'}"
     )
+    if backrest_enabled:
+        print(f"# {bold_start}BackRest Storage Path{bold_end} : {backrest_storage_path}")
+        print(f"# {bold_start}BackRest Archive Mode{bold_end} : {backrest_archive_mode}")
+        print(f"# {bold_start}BackRest Repository Type{bold_end} : {repo1_type}")
+    print(f"# {bold_start}Number of Nodes{bold_end}    : {num_nodes}")
+    print(f"# {bold_start}Database Name{bold_end}      : {db}")
+    print(f"# {bold_start}User{bold_end}               : {usr}")
+    for idx, node in enumerate(node_groups, start=1):
+        print(f"# {bold_start}Node {idx}{bold_end}")
+        print(f"#      {bold_start}Public IP{bold_end}     : {node['public_ip']}")
+        print(f"#      {bold_start}Private IP{bold_end}    : {node['private_ip']}")
+        print(f"#      {bold_start}Port{bold_end}          : {node['port']}")
+    
     print("#" * 80)
 
     if not force:

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -896,7 +896,7 @@ def json_create(
         backrest_enabled = False
     else:
         backrest_enabled_input = (
-            input("Do you want to enable BackRest for this cluster? (Y/N): ")
+            input("Enable pgBackRest? (Y/N) (default: 'N'): ")
             .strip()
             .lower()
         )
@@ -925,7 +925,7 @@ def json_create(
         )
         if repo1_type not in ["posix", "s3"]:
             util.exit_message(
-                "Invalid BackRest repository type. Allowed values are 'posix' or 's3'."
+                "Invalid pgBackRest repository type. Allowed values are 'posix' or 's3'."
             )
         backrest_json = {
             "stanza": "demo_stanza",
@@ -1186,11 +1186,11 @@ def json_create(
     print(
         f"# {bold_start}Spock Version{bold_end}      : {spock_version if spock_version else 'Not specified'}"
     )
+    # print(
+    #     f"# {bold_start}HA Cluster{bold_end}         : {'Yes' if is_ha_cluster else 'No'}"
+    # )
     print(
-        f"# {bold_start}HA Cluster{bold_end}         : {'Yes' if is_ha_cluster else 'No'}"
-    )
-    print(
-        f"# {bold_start}BackRest Enabled{bold_end}   : {'Yes' if backrest_enabled else 'No'}"
+        f"# {bold_start}pgBackRest Enabled{bold_end}   : {'Yes' if backrest_enabled else 'No'}"
     )
     print("#" * 80)
 

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -719,7 +719,7 @@ def json_create(
     cluster_name, num_nodes, db, usr, passwd, pg_ver=None, port=None, force=False
 ):
     """
-    Create a Cluster Configuration JSON file with options for HA, BackRest, and Spock.
+    Create a Cluster Configuration JSON file with options for BackRest, and Spock.
 
     Usage:
         ./pgedge cluster json-create CLUSTER_NAME NUM_NODES DB USR PASSWD [pg_ver=PG_VERSION] [--port PORT]

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -845,7 +845,7 @@ def json_create(
                 pg_input = str(pg_version_int)
             else:
                 pg_input = (
-                    input(f"PostgreSQL version {pgs} [default: {pg_default}]: ").strip()
+                    input(f"PostgreSQL version {pgs} (default: {pg_default}): ").strip()
                     or pg_default
                 )
 
@@ -864,7 +864,7 @@ def json_create(
         while True:
             spock_version = (
                 input(
-                    f"Spock version {spocks} [default: {spock_default}]: "
+                    f"Spock version {spocks} (default: {spock_default}): "
                 ).strip()
                 or spock_default
             )
@@ -959,13 +959,13 @@ def json_create(
         else:
             public_ip = (
                 input(
-                    f"  Public IP address for Node {n} (leave blank for default '{default_ip}'): "
+                    f"  Public IP address for Node {n} (default: '{default_ip}'): "
                 ).strip()
                 or default_ip
             )
             private_ip = (
                 input(
-                    f"  Private IP address for Node {n} (leave blank to use public IP '{public_ip}'): "
+                    f"  Private IP address for Node {n} (default: '{public_ip}'): "
                 ).strip()
                 or public_ip
             )
@@ -984,7 +984,7 @@ def json_create(
             node_default_port = default_port
             while True:
                 node_port_input = input(
-                    f"  PostgreSQL port for Node {n} (leave blank for default '{node_default_port}'): "
+                    f"  PostgreSQL port for Node {n} (default: '{node_default_port}'): "
                 ).strip()
                 if not node_port_input:
                     node_port = node_default_port
@@ -1040,13 +1040,13 @@ def json_create(
 
                 public_ip = (
                     input(
-                        f"    Public IP address of replica Node {i} (leave blank for default '{default_ip}'): "
+                        f"    Public IP address of replica Node {i} (default: '{default_ip}'): "
                     ).strip()
                     or default_ip
                 )
                 private_ip = (
                     input(
-                        f"    Private IP address of replica Node {i} (leave blank to use public IP '{public_ip}'): "
+                        f"    Private IP address of replica Node {i} (default: '{public_ip}'): "
                     ).strip()
                     or public_ip
                 )
@@ -1055,7 +1055,7 @@ def json_create(
 
                 while True:
                     replica_port_input = input(
-                        f"    PostgreSQL port of replica Node {i} (leave blank for default '{current_replica_port}'): "
+                        f"    PostgreSQL port of replica Node {i} (default: '{current_replica_port}'): "
                     ).strip()
                     if not replica_port_input:
                         replica_port = current_replica_port

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -845,7 +845,7 @@ def json_create(
                 pg_input = str(pg_version_int)
             else:
                 pg_input = (
-                    input(f"PostgreSQL version {pgs} [default: {pg_ver}]: ").strip()
+                    input(f"PostgreSQL version {pgs} [default: {pg_default}]: ").strip()
                     or pg_default
                 )
 
@@ -864,7 +864,7 @@ def json_create(
         while True:
             spock_version = (
                 input(
-                    f"Spock version (e.g., {spocks}) or press Enter for default: "
+                    f"Spock version {spocks} [default: {spock_default}]: "
                 ).strip()
                 or spock_default
             )

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -719,7 +719,7 @@ def json_create(
     cluster_name, num_nodes, db, usr, passwd, pg_ver=None, port=None, force=False
 ):
     """
-    Create a Cluster Configuration JSON file with options for BackRest, and Spock.
+    Create a Cluster Configuration JSON file with options for pgBackRest and Spock.
 
     Usage:
         ./pgedge cluster json-create CLUSTER_NAME NUM_NODES DB USR PASSWD [pg_ver=PG_VERSION] [--port PORT]

--- a/cli/scripts/meta.py
+++ b/cli/scripts/meta.py
@@ -313,7 +313,7 @@ def get_default_spock(pgv):
         c.execute(sql)
         data = c.fetchall()
         for comp in data:
-            spock_ver_minor = comp[0][0:5]
+            spock_ver_minor = comp[0].split('-')[0]
             avail_spock.append(spock_ver_minor)
             if f"{default_spock[0]}.{default_spock[1]}" in spock_ver_minor:
                 default_spock = spock_ver_minor

--- a/cli/scripts/util.py
+++ b/cli/scripts/util.py
@@ -5,7 +5,7 @@ import os
 import time
 
 MY_VERSION = "25.0.0"
-MY_CODENAME = "Constellation"
+MY_CODENAME = ""
 
 DEFAULT_PG = "16"
 DEFAULT_SPOCK = "40"
@@ -254,7 +254,7 @@ def format_ver(p_ver):
         message(f"'{p_ver}' is not a valid three part version string", "warning")
         return(p_ver)
 
-    return(f"{v[0]}.{str(v[1]).rjust(2,'0')}-{v[2]}")
+    return(f"{v[0]}.{v[1]}-{v[2]}")
 
 
 def autostart_verify_prereqs():


### PR DESCRIPTION
- Display default values consistently across inputs
- Fix issue where spock versions with revisions would be truncated
- Improve json-create summary output

Fixes along the way:
- Hide HA note in summary
- Remove release codename (for now)

```
$ ./pgedge cluster json-create default 2 defaultdb admin password
PostgreSQL version ['15', '16', '17'] (default: '16'):
Spock version ['3.3.6', '3.3.5', '4.0.10', '4.0.9', '4.0.8'] (default: '4.0.10'):
Enable pgBackRest? (Y/N) (default: 'N'): Y
   pgBackRest storage path (default: '/var/lib/pgbackrest'):
   pgBackRest archive mode (on/off) (default: 'on'):
   pgBackRest repository type (posix/s3) (default: 'posix'):

Configuring Node 1
  Public IP address for Node 1 (default: '127.0.0.1'):
  Private IP address for Node 1 (default: '127.0.0.1'):
  PostgreSQL port for Node 1 (default: '5432'):

Configuring Node 2
  Public IP address for Node 2 (default: '127.0.0.1'):
  Private IP address for Node 2 (default: '127.0.0.1'):
  PostgreSQL port for Node 2 (default: '5432'):

################################################################################
# Cluster Name       : default
# PostgreSQL Version : 16
# Spock Version      : 4.0.10
# Number of Nodes    : 2
# Database Name      : defaultdb
# User               : admin
# pgBackRest Enabled : Yes
#    Storage Path    : /var/lib/pgbackrest
#    Archive Mode    : on
#    Repository Type : posix
# Node 1
#    Public IP       : 127.0.0.1
#    Private IP      : 127.0.0.1
#    Port            : 5432
# Node 2
#    Public IP       : 127.0.0.1
#    Private IP      : 127.0.0.1
#    Port            : 5432
################################################################################
Do you want to save this configuration? (Y/N): Y

Cluster configuration saved to /home/pgedge/pgedge/cluster/default/default.json
```