### PR TITLE
Versioning changes for 24.10.12 release

### DIFF
--- a/bp.sh
+++ b/bp.sh
@@ -24,9 +24,10 @@ fi
 ./devel/startHTTP.sh
 
 echo "Waiting for Python HTTP server to start..."
-while ! nc -z localhost 8000; do
-  sleep 1  # Check every second
+while ! ss -tln | grep -q ':8000'; do 
+ sleep 1; 
 done
+
 
 echo "HTTP server is up!"
 

--- a/cli/scripts/install.py
+++ b/cli/scripts/install.py
@@ -3,7 +3,7 @@
 
 import sys, os, tarfile, platform
 
-VER = "24.10.11"
+VER = "24.10.12"
 REPO = os.getenv("REPO", "https://pgedge-download.s3.amazonaws.com/REPO")
 
 if sys.version_info < (3, 9):

--- a/cli/scripts/util.py
+++ b/cli/scripts/util.py
@@ -4,7 +4,7 @@
 import os
 import time
 
-MY_VERSION = "24.10.11"
+MY_VERSION = "24.10.12"
 MY_CODENAME = "Constellation"
 
 DEFAULT_PG = "16"

--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,5 @@
-hubV=24.10.11
-hubVV=24.10-11
+hubV=24.10.12
+hubVV=24.10-12
 
 aceV=$hubV
 kirkV=$hubV

--- a/src/conf/versions.sql
+++ b/src/conf/versions.sql
@@ -1,7 +1,7 @@
 
 DROP TABLE IF EXISTS hub;
 CREATE TABLE hub(v TEXT NOT NULL PRIMARY KEY, c TEXT NOT NULL, d TEXT NOT NULL);
-INSERT INTO hub VALUES ('24.10.11', 'Constellation',  '20250224');
+INSERT INTO hub VALUES ('24.10.12', 'Constellation',  '20250314');
 
 DROP VIEW  IF EXISTS v_versions;
 DROP VIEW  IF EXISTS v_products;
@@ -139,6 +139,7 @@ INSERT INTO projects VALUES ('hub', 'app', 0, 0, 'hub', 0, 'https://github.com/p
 INSERT INTO releases VALUES ('hub', 1, 'hub',  '', '', 'hidden', '', 1, '', '', '');
 
 INSERT INTO versions VALUES ('hub', (select v from hub), '',  1, (select d from hub), '', '', '');
+INSERT INTO versions VALUES ('hub', '24.10.11',  '',  0, '20250224', '', '', '');
 INSERT INTO versions VALUES ('hub', '24.10.10',  '',  0, '20250123', '', '', '');
 INSERT INTO versions VALUES ('hub', '24.10.9',   '',  0, '20241206', '', '', '');
 INSERT INTO versions VALUES ('hub', '24.10.7',   '',  0, '20241125', '', '', '');


### PR DESCRIPTION
1. Versioning changes related to` 24.10.12` release
2. Replacing `nc` with `ss` for checking if the HTTP server is running, as nc is not installed by default on many Linux systems.