### PR TITLE
Enable Daily Platform Builds to pgedge-devel

### DIFF
--- a/.github/workflows/daily-build-devel-amd8.yml
+++ b/.github/workflows/daily-build-devel-amd8.yml
@@ -1,0 +1,184 @@
+name: Stable Daily Build Devel - amd8
+
+on:
+  workflow_dispatch:
+    inputs:
+      cli_branch:
+        description: "Select the CLI branch to build from"
+        required: true
+        default: REL25_01
+        type: choice
+        options:
+          - REL25_01
+          - REL24_10
+
+      prefix_selector:
+        description: "Choose target pgedge-devel repo sub-directory (default = MMDD, custom = your input). Packages will be at: https://pgedge-devel.s3.amazonaws.com/REPO/stable/<sub-dir>"
+        required: true
+        default: "default"
+        type: choice
+        options:
+          - default
+          - custom
+
+      custom_prefix:
+        description: "If 'custom' selected above, provide sub-directory name"
+        required: false
+
+      clean_prefix:
+        description: "Clean the repo sub-directory before copying packages"
+        required: false
+        type: choice
+        options:
+          - "false"
+          - "true"
+        default: "false"
+
+  schedule:
+    - cron: "0 23 * * *"  # 11PM UTC = 7PM EST
+
+jobs:
+  build-stable-amd8:
+    runs-on: [self-hosted, amd8]
+
+    steps:
+      - name: Set build parameters and logfile
+        id: vars
+        run: |
+          source ~/.bashrc
+
+          echo "Resolving build parameters..."
+
+          TODAY=$(date +%m%d)
+          RUNNER_NAME="${{ runner.name }}"
+
+          # Determine s3 prefix (sub-directory)
+          # If the run is automated, set prefix to MMDD and no clean flag
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            PREFIX="$TODAY"
+            CLEAN_FLAG=""
+            SELECTED_CLI_BRANCH="${{ inputs.cli_branch }}"
+            echo "Scheduled run: Prefix=$PREFIX, Clean flag not set, Branch=$SELECTED_CLI_BRANCH"
+          else
+            # Manually triggered workflow
+            # If sub-directory prefix chosen is default, set prefix to MMDD 
+            if [[ "${{ inputs.prefix_selector }}" == "default" ]]; then
+              PREFIX="$TODAY"
+              echo "Manual run: Using default prefix: $PREFIX"
+            else
+              # If sub-directory prefix chosen is custom, check a custom value is input or exit
+              if [[ -z "${{ inputs.custom_prefix }}" ]]; then
+                echo "Error: Custom prefix selected but no input provided."
+                exit 1
+              fi
+              # Set prefix to user specified value
+              PREFIX="${{ inputs.custom_prefix }}"
+              echo "Manual run: Using custom prefix: $PREFIX"
+            fi
+
+            # Clean flag handling
+            # If true is chosen in the clean dropdown, set the --clean flag
+            if [[ "${{ inputs.clean_prefix }}" == "true" ]]; then
+              CLEAN_FLAG="--clean"
+              echo "Clean flag is enabled"
+            else
+              CLEAN_FLAG=""
+              echo "Clean flag is disabled"
+            fi
+
+            # Branch input
+            SELECTED_CLI_BRANCH="${{ inputs.cli_branch }}"
+            echo "Manual run: Selected CLI branch: $SELECTED_CLI_BRANCH"
+          fi
+
+          # Set timestamped log file
+          TIMESTAMP=$(date +%m%d%y-%H%M)
+          LOGFILE_NAME="build_to_devel-${RUNNER_NAME}-${TIMESTAMP}.log"
+          LOGFILE_PATH="/tmp/${LOGFILE_NAME}"
+
+          # Export environment variables that will be referred in subsequent steps
+          echo "RUNNER_NAME=$RUNNER_NAME" >> $GITHUB_ENV
+          echo "PREFIX=$PREFIX" >> $GITHUB_ENV
+          echo "CLEAN_FLAG=$CLEAN_FLAG" >> $GITHUB_ENV
+          echo "LOGFILE_PATH=$LOGFILE_PATH" >> $GITHUB_ENV
+          echo "CLI_BRANCH=$SELECTED_CLI_BRANCH" >> $GITHUB_ENV
+
+          echo "Log file will be created at: $LOGFILE_PATH"
+
+      - name: Show effective configuration
+        run: |
+          echo "Runner: $RUNNER_NAME"
+          echo "Prefix: $PREFIX"
+          echo "Clean flag: $CLEAN_FLAG"
+          echo "Log file path: $LOGFILE_PATH"
+          echo "CLI branch: $CLI_BRANCH"
+
+      - name: Confirm environment and switching to required cli branch
+        id: cli_branch_checkout
+        run: |
+          source ~/.bashrc
+          echo "OS info:"
+          cat /etc/os-release
+          echo "Architecture:"
+          arch
+
+          echo "Navigating to CLI and safely checking out specified branch..."
+          cd $PGE
+
+          echo "Current branch and status:"
+          git branch
+          git status
+
+          echo "Stashing changes (if any)..."
+          git stash push -u -m "Temp stash for branch switch" || true
+
+          echo "Checking out branch: $CLI_BRANCH"
+          git checkout "$CLI_BRANCH" || true
+
+      - name: Run build and push to devel repo
+        id: build_to_devel
+        run: |
+          source ~/.bashrc
+
+          echo "Launching daily build script..."
+          cd $DEV
+
+          echo "Executing: ./build_to_tempdvl.sh $PREFIX $CLEAN_FLAG"
+          #echo "Executing: ./build_to_tempdvl.sh $PREFIX $CLEAN_FLAG" > "$LOGFILE_PATH" 2>&1
+          ./build_to_tempdvl.sh "$PREFIX" $CLEAN_FLAG > "$LOGFILE_PATH" 2>&1
+          EXIT_CODE=$?
+          #EXIT_CODE=0
+
+          echo "Build finished with exit code: $EXIT_CODE"
+
+          if [[ $EXIT_CODE -ne 0 ]]; then
+            echo "Build failed. Check the log for details."
+            exit $EXIT_CODE
+          fi
+
+      - name: Upload build log artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-log
+          path: ${{ env.LOGFILE_PATH }}
+          if-no-files-found: warn
+
+      - name: Cleanup build artifacts
+        if: steps.build_to_devel.outcome == 'success'
+        continue-on-error: true
+        run: |
+          source ~/.bashrc
+          # ensuring an unsuccessful deletion of this dir doesn't cause the entire job to fail
+          run_day=$(date +%j)
+          TARGET="$HIST/devel-$run_day"
+          echo "Attempting to remove: $TARGET"
+      
+          if [ -d "$TARGET" ]; then
+            rm -rf "$TARGET"
+            echo "Successfully removed $TARGET"
+          else
+            echo "Directory $TARGET does not exist. Nothing to clean."
+          fi
+
+

--- a/.github/workflows/daily-build-devel-arm9.yml
+++ b/.github/workflows/daily-build-devel-arm9.yml
@@ -1,0 +1,182 @@
+name: Stable Daily Build Devel - arm9
+
+on:
+  workflow_dispatch:
+    inputs:
+      cli_branch:
+        description: "Select the CLI branch to build from"
+        required: true
+        default: REL25_01
+        type: choice
+        options:
+          - REL25_01
+          - REL24_10
+
+      prefix_selector:
+        description: "Choose target pgedge-devel repo sub-directory (default = MMDD, custom = your input). Packages will be at: https://pgedge-devel.s3.amazonaws.com/REPO/stable/<sub-dir>"
+        required: true
+        default: "default"
+        type: choice
+        options:
+          - default
+          - custom
+
+      custom_prefix:
+        description: "If 'custom' selected above, provide sub-directory name"
+        required: false
+
+      clean_prefix:
+        description: "Clean the repo sub-directory before copying packages"
+        required: false
+        type: choice
+        options:
+          - "false"
+          - "true"
+        default: "false"
+
+  schedule:
+    - cron: "30 23 * * *"  # 11:30PM UTC = 7:30PM EST
+
+jobs:
+  build-stable-arm9:
+    runs-on: [self-hosted, arm9]
+
+    steps:
+      - name: Set build parameters and logfile
+        id: vars
+        run: |
+          source ~/.bashrc
+
+          echo "Resolving build parameters..."
+
+          TODAY=$(date +%m%d)
+          RUNNER_NAME="${{ runner.name }}"
+
+          # Determine s3 prefix (sub-directory)
+          # If the run is automated, set prefix to MMDD and no clean flag
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            PREFIX="$TODAY"
+            CLEAN_FLAG=""
+            SELECTED_CLI_BRANCH="${{ inputs.cli_branch }}"
+            echo "Scheduled run: Prefix=$PREFIX, Clean flag not set, Branch=$SELECTED_CLI_BRANCH"
+          else
+            # Manually triggered workflow
+            # If sub-directory prefix chosen is default, set prefix to MMDD 
+            if [[ "${{ inputs.prefix_selector }}" == "default" ]]; then
+              PREFIX="$TODAY"
+              echo "Manual run: Using default prefix: $PREFIX"
+            else
+              # If sub-directory prefix chosen is custom, check a custom value is input or exit
+              if [[ -z "${{ inputs.custom_prefix }}" ]]; then
+                echo "Error: Custom prefix selected but no input provided."
+                exit 1
+              fi
+              # Set prefix to user specified value
+              PREFIX="${{ inputs.custom_prefix }}"
+              echo "Manual run: Using custom prefix: $PREFIX"
+            fi
+
+            # Clean flag handling
+            # If true is chosen in the clean dropdown, set the --clean flag
+            if [[ "${{ inputs.clean_prefix }}" == "true" ]]; then
+              CLEAN_FLAG="--clean"
+              echo "Clean flag is enabled"
+            else
+              CLEAN_FLAG=""
+              echo "Clean flag is disabled"
+            fi
+
+            # Branch input
+            SELECTED_CLI_BRANCH="${{ inputs.cli_branch }}"
+            echo "Manual run: Selected CLI branch: $SELECTED_CLI_BRANCH"
+          fi
+
+          # Set timestamped log file
+          TIMESTAMP=$(date +%m%d%y-%H%M)
+          LOGFILE_NAME="build_to_devel-${RUNNER_NAME}-${TIMESTAMP}.log"
+          LOGFILE_PATH="/tmp/${LOGFILE_NAME}"
+
+          # Export environment variables that will be referred in subsequent steps
+          echo "RUNNER_NAME=$RUNNER_NAME" >> $GITHUB_ENV
+          echo "PREFIX=$PREFIX" >> $GITHUB_ENV
+          echo "CLEAN_FLAG=$CLEAN_FLAG" >> $GITHUB_ENV
+          echo "LOGFILE_PATH=$LOGFILE_PATH" >> $GITHUB_ENV
+          echo "CLI_BRANCH=$SELECTED_CLI_BRANCH" >> $GITHUB_ENV
+
+          echo "Log file will be created at: $LOGFILE_PATH"
+
+      - name: Show effective configuration
+        run: |
+          echo "Runner: $RUNNER_NAME"
+          echo "Prefix: $PREFIX"
+          echo "Clean flag: $CLEAN_FLAG"
+          echo "Log file path: $LOGFILE_PATH"
+          echo "CLI branch: $CLI_BRANCH"
+
+      - name: Confirm environment and switching to required cli branch
+        id: cli_branch_checkout
+        run: |
+          source ~/.bashrc
+          echo "OS info:"
+          cat /etc/os-release
+          echo "Architecture:"
+          arch
+
+          echo "Navigating to CLI and safely checking out specified branch..."
+          cd $PGE
+
+          echo "Current branch and status:"
+          git branch
+          git status
+
+          echo "Stashing changes (if any)..."
+          git stash push -u -m "Temp stash for branch switch" || true
+
+          echo "Checking out branch: $CLI_BRANCH"
+          git checkout "$CLI_BRANCH" || true
+
+      - name: Run build and push to devel repo
+        id: build_to_devel
+        run: |
+          source ~/.bashrc
+
+          echo "Launching daily build script..."
+          cd $DEV
+
+          echo "Executing: ./build_to_tempdvl.sh $PREFIX $CLEAN_FLAG"
+          #echo "Executing: ./build_to_tempdvl.sh $PREFIX $CLEAN_FLAG" > "$LOGFILE_PATH" 2>&1
+          ./build_to_tempdvl.sh "$PREFIX" $CLEAN_FLAG > "$LOGFILE_PATH" 2>&1
+          EXIT_CODE=$?
+          #EXIT_CODE=0
+
+          echo "Build finished with exit code: $EXIT_CODE"
+
+          if [[ $EXIT_CODE -ne 0 ]]; then
+            echo "Build failed. Check the log for details."
+            exit $EXIT_CODE
+          fi
+
+      - name: Upload build log artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-log
+          path: ${{ env.LOGFILE_PATH }}
+          if-no-files-found: warn
+
+      - name: Cleanup build artifacts
+        if: steps.build_to_devel.outcome == 'success'
+        continue-on-error: true
+        run: |
+          source ~/.bashrc
+          # ensuring an unsuccessful deletion of this dir doesn't cause the entire job to fail
+          run_day=$(date +%j)
+          TARGET="$HIST/devel-$run_day"
+          echo "Attempting to remove: $TARGET"
+      
+          if [ -d "$TARGET" ]; then
+            rm -rf "$TARGET"
+            echo "Successfully removed $TARGET"
+          else
+            echo "Directory $TARGET does not exist. Nothing to clean."
+          fi

--- a/devel/util/build_to_devel.sh
+++ b/devel/util/build_to_devel.sh
@@ -2,12 +2,36 @@
 cd "$(dirname "$0")"
 
 source $PGE/env.sh
+
+# Show progress updates if stdout is a terminal;
+# if not (e.g. redirected to a log file), disable them to avoid s3 copy progress noise
+if [ -t 1 ]; then
+  PROGRESS_FLAG=""
+else
+  PROGRESS_FLAG="--no-progress"
+fi
+
+# Global variable to track the current step.
+CURRENT_STEP="Initialization"
+
+# Set a trap to catch any errors and report the current step.
+trap 'echo "ERROR: Failure during step: $CURRENT_STEP"; exit 1' ERR
+
+# --- S3 Bucket and Name Declarations ---
+# Set the S3 bucket (change this as needed)
+export BUCKET="s3://pgedge-devel"
+
 # offline tgz bundle name
 offline_tgz_bndl="pgedge-$hubVV-$OS.tgz"
 
+# Export the bucket name (remove s3://) only as some s3 commands require bucket name only
+export BUCKET_NAME=$(echo $BUCKET | sed 's#s3://##')
+
+# Functions
+
 cmd () {
   echo "# $1"
-  eval "$1"  # Use eval to properly handle nested quotes
+  eval "$1"
   rc=$?
   if [ ! "$rc" == "0" ]; then
     echo "ERROR: rc=$rc  Stopping Script"
@@ -16,13 +40,80 @@ cmd () {
 }
 
 step () {
+  CURRENT_STEP="$1 - $2"
+  local ts
+  ts=$(date '+%Y-%m-%d %H:%M:%S')
   echo ""
-  echo "## step $1 - $2"
+  echo "[$ts] ## step $CURRENT_STEP"
 }
 
+# Check required environment variables.
+check_env_vars() {
+  if [ -z "$PGE" ] || [ -z "$OUT" ] || [ -z "$HIST" ]; then
+    echo "ERROR: One or more required environment variables are not set."
+    echo "PGE: '$PGE', OUT: '$OUT', HIST: '$HIST'"
+    exit 1
+  fi
+}
+
+# Ensure around 5GB free space is available on the filesystem containing $OUT.
+check_disk_space() {
+  # Required is approx 2.5GB, keeping a check around 5GB to account for interim files.
+  REQUIRED_DISK=5000000
+  available=$(df -P "$OUT" | awk 'NR==2 {print $4}')
+  echo "Disk space available on $OUT: ${available} KB (Required: ${REQUIRED_DISK} KB)"
+  if [ "$available" -lt "$REQUIRED_DISK" ]; then
+    echo "ERROR: Not enough disk space to build platform packages. Approx 5GB required"
+    exit 1
+  fi
+}
+
+# Check that the S3 bucket is accessible.
+check_s3_access() {
+  if ! aws --region $REGION s3api head-bucket --bucket "$BUCKET_NAME" > /dev/null 2>&1; then
+    echo "ERROR: S3 bucket $BUCKET_NAME does not exist or is not accessible."
+    exit 1
+  fi
+}
+
+# --- Pre-checks (Step -1) ---
+step -1 "Pre-checks: Environment, Disk Space & S3 Access"
+
+check_env_vars
+check_disk_space
+check_s3_access
+
+# -------------------------------
+# New Argument Parsing for Subdirectory and Clean Flag
+# Usage: ./build_to_devel.sh [subdirectory] [--clean]
+# If no custom subdirectory is provided then MMDD is used and --clean is not set.
+subdir=$(date +%m%d)
+cleaner=""
+
+# Parse input arguments
+if [ "$1" == "--clean" ]; then
+  cleaner="--clean"
+  shift
+fi
+
+if [ -n "$1" ]; then
+  subdir="$1"
+  if [ "$2" == "--clean" ]; then
+    cleaner="--clean"
+  fi
+fi
+
+echo "# Using subdirectory: $subdir"
+if [ "$cleaner" == "--clean" ]; then
+  echo "# Clean flag is set"
+fi
+
+# Calculate S3 path prefix (REPO/stable/<subdir>)
+prefix="REPO/stable/$subdir"
+echo "# Using S3 prefix: $prefix"
+# -------------------------------
 
 step 0 "## initialization  #######################"
-export BUCKET=s3://pgedge-devel
 echo "#  BUCKET = $BUCKET"
 
 now=`date '+%F %r %Z'`
@@ -32,7 +123,6 @@ run_day=`date +%j`
 echo "# run_day = $run_day"
 
 vers="15 16 17"
-cleaner="$1"
 echo "#     vers = \"$vers\""
 
 if [ "$vers" == "" ]; then
@@ -52,8 +142,9 @@ cmd "git status"
 cmd "git pull"
 
 step 3a "building tgz bundle ####################"
+echo "Building tgz bundle : $offline_tgz_bndl"
 ./make_tgz.sh
-
+sleep 9
 # Verify that the offline tarball was created
 if [ ! -f "$OUT/$offline_tgz_bndl" ]; then
     echo "ERROR: make_tgz.sh did not generate expected tarball: $offline_tgz_bndl"
@@ -68,17 +159,35 @@ sleep 3
 
 step 5 "check if cleanup S3 ###################"
 if [ "$cleaner" == "--clean" ]; then
-  cmd "aws --region $REGION s3 rm --recursive $BUCKET/REPO"
+  cmd "aws --region $REGION s3 rm --recursive $BUCKET/$prefix"
 fi
 
+# s3 copy
 step 6 "copy to S3 ############################"
 flags="--acl public-read --storage-class STANDARD --recursive"
-cmd "aws --region $REGION s3 cp . $BUCKET/REPO $flags"
+cmd "aws --region $REGION s3 cp . $BUCKET/$prefix $flags $PROGRESS_FLAG"
 
-# Step 6a - Re-upload the offline tarball with content-disposition headers  
-# so pgedge-latest-{arch}.tgz downloads with its versioned filename.  
+# Step 6a - Re-upload the offline tarball with content-disposition headers
+# so pgedge-latest-{arch}.tgz downloads with its versioned filename.
 step 6a "recopy offline repo tgz to S3 with headers ############################"
-cmd "aws --region $REGION s3 cp $offline_tgz_bndl $BUCKET/REPO/ --acl public-read --content-disposition \"attachment; filename=$offline_tgz_bndl\""
+cmd "aws --region $REGION s3 cp $offline_tgz_bndl $BUCKET/$prefix/ --acl public-read --content-disposition \"attachment; filename=$offline_tgz_bndl\" $PROGRESS_FLAG"
+
+# Define a lifecycle policy JSON for all objects under the REPO/stable to auto expire after 7 days
+step 6b "Set lifecycle policy for the objects under REPO/stable to auto expire/delete after 7 days"
+policy='{
+  "Rules": [
+    {
+      "ID": "ExpireStableBuilds",
+      "Filter": { "Prefix": "REPO/stable/" },
+      "Status": "Enabled",
+      "Expiration": { "Days": 7 }
+    }
+  ]
+}'
+cmd "aws --region $REGION s3api put-bucket-lifecycle-configuration --bucket $BUCKET_NAME --lifecycle-configuration '$policy'"
 
 step 7 "Goodbye! ##############################"
+echo "Script completed successfully"
 exit 0
+
+

--- a/devel/util/cp-devel-to-download.sh
+++ b/devel/util/cp-devel-to-download.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 cd "$(dirname "$0")"
 
+# Validate required sub-directory prefix 
+if [ -z "$1" ]; then
+  echo "ERROR: Missing required S3 sub-directory prefix for devel repo."
+  echo "Usage: $0 <devel_subdir>"
+  exit 1
+fi
+# capture input sub-dir prefix 
+devel_input_subdir="$1"
+
 # Source and destination s3 buckets, and the prefix
 from_bucket="pgedge-devel"
 to_bucket="pgedge-download"
-prefix="REPO/"
+# Construct final source prefix using the provided sub-directory (s3 prefix)
+prefix="REPO/stable/$devel_input_subdir"
 
 # Flags for the s3api copy-object command preserving metadata
 flags="--acl public-read --storage-class STANDARD --metadata-directive COPY"
@@ -14,14 +24,15 @@ log_file="/tmp/s3-copy-errors-$(date +%Y%m%d-%H%M).log"
 
 echo "Listing objects in s3://$from_bucket/$prefix..."
 object_keys=$(aws s3api list-objects --bucket "$from_bucket" --prefix "$prefix" --query "Contents[].Key" --output text)
-# if nothing to copy, exit
-if [ -z "$object_keys" ]; then
-  echo "No objects found in s3://$from_bucket/$prefix."
+if [ -z "$object_keys" ] || [ "$object_keys" = "None" ]; then
+  error_message="ERROR: No objects found in s3://$from_bucket/$prefix. Check that the sub-directory exists."
+  echo "$error_message"
+  echo "$error_message" >> "$log_file"
   exit 1
 fi
 
 # Batch copying, Set the maximum number of concurrent copy jobs
-max_jobs=12
+max_jobs=15
 job_count=0
 
 # Copy between buckets in the background &
@@ -51,3 +62,4 @@ if [ -s "$log_file" ]; then
   echo "Warning: Some files may have failed to copy. Please check the log file at: $log_file"
   exit 1
 fi
+

--- a/devel/util/cp-devel-to-upstream.sh
+++ b/devel/util/cp-devel-to-upstream.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 cd "$(dirname "$0")"
 
+# Validate required sub-directory prefix 
+if [ -z "$1" ]; then
+  echo "ERROR: Missing required S3 sub-directory prefix for devel repo."
+  echo "Usage: $0 <devel_subdir>"
+  exit 1
+fi
+# capture input sub-dir prefix 
+devel_input_subdir="$1"
+
 # Source and destination s3 buckets, and the prefix
 from_bucket="pgedge-devel"
 to_bucket="pgedge-upstream"
-prefix="REPO/"
+# Construct final source prefix using the provided sub-directory (s3 prefix)
+prefix="REPO/stable/$devel_input_subdir"
 
 # Flags for the s3api copy-object command preserving metadata
 flags="--acl public-read --storage-class STANDARD --metadata-directive COPY"
@@ -14,14 +24,15 @@ log_file="/tmp/s3-copy-errors-$(date +%Y%m%d-%H%M).log"
 
 echo "Listing objects in s3://$from_bucket/$prefix..."
 object_keys=$(aws s3api list-objects --bucket "$from_bucket" --prefix "$prefix" --query "Contents[].Key" --output text)
-# if nothing to copy, exit
-if [ -z "$object_keys" ]; then
-  echo "No objects found in s3://$from_bucket/$prefix."
+if [ -z "$object_keys" ] || [ "$object_keys" = "None" ]; then
+  error_message="ERROR: No objects found in s3://$from_bucket/$prefix. Check that the sub-directory exists."
+  echo "$error_message"
+  echo "$error_message" >> "$log_file"
   exit 1
 fi
 
 # Batch copying, Set the maximum number of concurrent copy jobs
-max_jobs=12
+max_jobs=15
 job_count=0
 
 # Copy between buckets in the background &
@@ -51,3 +62,4 @@ if [ -s "$log_file" ]; then
   echo "Warning: Some files may have failed to copy. Please check the log file at: $log_file"
   exit 1
 fi
+


### PR DESCRIPTION
This PR introduces daily build workflows (parmaterised) for the pgEdge platform, supporting both scheduled and manual triggers via GitHub Actions. It also includes updates to helper build scripts to align with a new subdirectory-based S3 layout for managing daily and custom stable builds.

### Summary of Changes in this PR (corresponding commits have more details of the changes)

- **Workflows Added (amd8 and arm9):**  
  - Set to run daily (11:00 PM UTC for amd8, 11:30 PM UTC for arm9), or can be triggered manually using a form-style interface.  
  - Parameters include the CLI branch (`REL25_01`, `REL24_10`), an optional S3 subdirectory label (defaults to `MMDD`), and a --clean flag to wipe the target directory before upload.  
  - Runs on self-hosted runners (registered under the `pgedge/cli` project).  
  - Builds are uploaded to `s3://<bucket>/REPO/stable/<subdir>`  
  - Includes checks for environment readiness, collects build logs, and handles cleanup on success.

- **`build_to_devel.sh` Enhancements:**  
  - Adds sanity checks for required environment variables, disk space, and S3 access.  
  - Accepts a prefix subdirectory and cleanup flag as arguments.  
  - Applies lifecycle rules to clean up older (than 7 days) builds automatically.

- **`cp-devel-to-*` Script Updates:**  
  - Requires a `<subdir>` argument to locate the correct build directory in `pgedge-devel`.  
  - Validates the source S3 path, keeps existing support for parallel copying intact.

These changes introduce repeatable daily pgEdge platform builds for both supported architectures, organized cleanly under a subdirectory structure within the `pgedge-devel` repo.
These changes do not impact upstream and download repository structure, that stays the same for now.