### PR TITLE
[PLAT 69] Bug fix for Daily builds branch selection for scheduled mode (#307)

### DIFF
--- a/.github/workflows/daily-build-devel-amd8.yml
+++ b/.github/workflows/daily-build-devel-amd8.yml
@@ -1,5 +1,8 @@
 name: Stable Daily Build Devel - amd8
 
+env:
+  DEFAULT_CLI_BRANCH: "REL25_01"
+
 on:
   workflow_dispatch:
     inputs:
@@ -57,7 +60,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             PREFIX="$TODAY"
             CLEAN_FLAG=""
-            SELECTED_CLI_BRANCH="${{ inputs.cli_branch }}"
+            SELECTED_CLI_BRANCH="${DEFAULT_CLI_BRANCH}"
             echo "Scheduled run: Prefix=$PREFIX, Clean flag not set, Branch=$SELECTED_CLI_BRANCH"
           else
             # Manually triggered workflow

--- a/.github/workflows/daily-build-devel-arm9.yml
+++ b/.github/workflows/daily-build-devel-arm9.yml
@@ -1,5 +1,8 @@
 name: Stable Daily Build Devel - arm9
 
+env:
+  DEFAULT_CLI_BRANCH: "REL25_01"
+
 on:
   workflow_dispatch:
     inputs:
@@ -57,7 +60,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             PREFIX="$TODAY"
             CLEAN_FLAG=""
-            SELECTED_CLI_BRANCH="${{ inputs.cli_branch }}"
+            SELECTED_CLI_BRANCH="${DEFAULT_CLI_BRANCH}"
             echo "Scheduled run: Prefix=$PREFIX, Clean flag not set, Branch=$SELECTED_CLI_BRANCH"
           else
             # Manually triggered workflow


### PR DESCRIPTION
For scheduled runs, SELECTED_CLI_BRANCH was being set to ${{ inputs.cli_branch }}, which was empty because inputs aren’t provided in scheduled events. This resulted in an invalid git checkout, causing the build to potentially use an unintended (already checked out )branch on the self hosted runner, leading to inconsistent or incorrect builds.
The fix introduces DEFAULT_CLI_BRANCH as an environment variable set to "REL25_01" and uses it for scheduled runs.