### PR TITLE
add-node workflow: fix recovery and wal restore issues, improve clean up logic

### DIFF
--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -1844,13 +1844,13 @@ def add_node(
     message = f"Removing old data directory"
     run_cmd(cmd, target_node_data, message=message, verbose=verbose)
 
-    args = f"--repo1-path {repo1_path} --repo1-cipher-type {source_repo1_cipher_type} "
+    args = f"--repo1-path {repo1_path} --repo1-cipher-type {source_repo1_cipher_type} --type standby "
     if backup_id:
         args += f"--set={backup_id} "
 
     cmd = (
         f'{target_node_data["path"]}/pgedge/pgedge backrest command restore '
-        f"--repo1-type={source_repo1_type} --stanza={source_stanza} --no-archive "
+        f"--repo1-type={source_repo1_type} --stanza={source_stanza} "
         f'--pg1-path={target_node_data["path"]}/pgedge/data/{pgV} {args}'
     )
     message = f"Restoring backup"

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -1509,6 +1509,18 @@ def init(cluster_name, install=True):
                 verbose=verbose,
             )
 
+            # (g) Set BACKUP repo1-type to the node's repo1-type value
+            cmd_set_pg1_port = (
+                f"cd {node['path']}/pgedge && ./pgedge set BACKUP repo1-type {repo1_type}"
+            )
+            run_cmd(
+                cmd_set_pg1_port,
+                node=node,
+                message=f"Setting BACKUP repo1-type to {repo1_type} on node '{node['name']}'",
+                verbose=verbose,
+            )
+
+
             # -- Step 6: Create the pgBackRest stanza (this command uses --pg1-port because it connects to the DB)
             cmd_create_stanza = (
                 f"cd {node['path']}/pgedge && "
@@ -1517,7 +1529,8 @@ def init(cluster_name, install=True):
                 f"--pg1-path='{pg1_path}' "
                 f"--repo1-cipher-type={repo1_cipher_type} "
                 f"--pg1-port={port} "
-                f"--repo1-path={repo1_path}"
+                f"--repo1-path={repo1_path} "
+                f"--repo1-type={repo1_type}"
             )
             run_cmd(
                 cmd_create_stanza,
@@ -1795,6 +1808,7 @@ def add_node(
                 f"sudo mkdir -p {source_restore_path}",
                 f"./pgedge set BACKUP restore_path {source_restore_path}",
                 f"./pgedge set BACKUP repo1-host-user {source_node_data.get('os_user', 'postgres')}",
+                f"./pgedge set BACKUP repo1-type {source_repo1_type}",
                 f"./pgedge set BACKUP pg1-path {source_pg1_path}",
                 f"./pgedge set BACKUP pg1-user {source_node_data.get('os_user', 'postgres')}",
                 f"./pgedge set BACKUP pg1-port {source_port}",
@@ -1817,7 +1831,8 @@ def add_node(
             f"--pg1-path='{source_pg1_path}' "
             f"--repo1-cipher-type={source_repo1_cipher_type} "
             f"--pg1-port={source_port} "
-            f"--repo1-path={source_repo1_path}"
+            f"--repo1-path={source_repo1_path} "
+            f"--repo1-type={source_repo1_type}"
         )
         run_cmd(
             cmd_create_stanza_source,
@@ -2171,6 +2186,7 @@ def add_node(
             f"sudo chown -R {target_repo1_host_user}:{target_repo1_host_user} {target_repo1_path} && "
             f"cd {target_pgedge_dir} && ./pgedge set BACKUP repo1-path {target_repo1_path} && "
             f"cd {target_pgedge_dir} && ./pgedge set BACKUP repo1-host-user {target_repo1_host_user} && "
+            f"cd {target_pgedge_dir} && ./pgedge set BACKUP repo1-type {target_repo1_type} && "
             f"cd {target_pgedge_dir} && ./pgedge set BACKUP pg1-path {target_pg1_path} && "
             f"cd {target_pgedge_dir} && ./pgedge set BACKUP pg1-user {target_pg1_user} && "
             f"cd {target_pgedge_dir} && ./pgedge set BACKUP pg1-port {target_pg1_port} && "
@@ -2212,7 +2228,8 @@ def add_node(
             f"--pg1-path='{target_pg1_path}' "
             f"--repo1-cipher-type={target_repo1_cipher_type} "
             f"--pg1-port={target_pg1_port} "
-            f"--repo1-path={target_repo1_path}"
+            f"--repo1-path={target_repo1_path} "
+            f"--repo1-type={target_repo1_type}"
         )
         run_cmd(
             cmd=cmd_create_stanza_target,

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -1917,6 +1917,8 @@ def add_node(
     run_cmd(cmd, target_node_data, message=message, verbose=verbose)
 
     restore_args = (
+        # This line is required because pgbackrest will not include repo1-cipher-type
+        # by default when generating the restore_command
         f'--cmd="pgbackrest --repo1-cipher-type={source_repo1_cipher_type}" '
         f"--stanza={source_stanza} "
         f"--pg1-path={target_node_data['path']}/pgedge/data/{pgV} "

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -1383,7 +1383,7 @@ def init(cluster_name, install=True):
             pg1_path = f"{node['path']}/pgedge/data/pg{pg_version}"
             port = node["port"]  # Custom port from JSON
 
-            # -- Step 1: Install pgBackRest
+            # Install pgBackRest
             cmd_install_backrest = (
                 f"cd {node['path']}/pgedge && ./pgedge install backrest"
             )

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -1621,14 +1621,6 @@ def add_node(
             "public_ip", target_node_data.get("private_ip")
         )
 
-    # Log source and target node data
-    util.message(
-        f"Source node data: {json.dumps(source_node_data, indent=2)}", "info"
-    )
-    util.message(
-        f"Target node data: {json.dumps(target_node_data, indent=2)}", "info"
-    )
-
     # If backrest is not configured on the source node, install it
     if not source_backrest_cfg:
         # Step 1: Install pgBackRest on the source node

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -2187,21 +2187,21 @@ def add_node(
 
 def json_validate_add_node(data):
     """
-    Validate the structure of a node‑definition JSON file that will be fed to
-    the add‑node command.
+    Validate the structure of a node-definition JSON file that will be fed to
+    the add-node command.
 
     • The traditional checks (json_version, ssh, port, …) still apply.
     • A node_group is not required to have a “backrest” block.
     • If a “backrest” block is present, it must contain at least:
-         • stanza        – unique stanza name
-         • repo1_path    – absolute path to the repo directory
-         • repo1_type    – 'posix' or 's3'
-       and the values must be non‑empty and valid.
+         • stanza        - unique stanza name
+         • repo1_path    - absolute path to the repo directory
+         • repo1_type    - 'posix' or 's3'
+       and the values must be non-empty and valid.
     """
 
     required_top = {"json_version", "node_groups"}
     if not required_top.issubset(data):
-        util.exit_message("Invalid add‑node JSON: missing json_version or node_groups.")
+        util.exit_message("Invalid add-node JSON: missing json_version or node_groups.")
 
     if str(data.get("json_version")) != "1.0":
         util.exit_message("Invalid or unsupported json_version (must be '1.0').")
@@ -2227,7 +2227,7 @@ def json_validate_add_node(data):
         missing_basic = node_group_required - set(group.keys())
         if missing_basic:
             util.exit_message(
-                f"Node‑group '{gname}' missing keys: {', '.join(missing_basic)}"
+                f"Node-group '{gname}' missing keys: {', '.join(missing_basic)}"
             )
 
         # ssh block
@@ -2235,7 +2235,7 @@ def json_validate_add_node(data):
         missing_ssh = ssh_required - set(ssh_info.keys())
         if missing_ssh:
             util.exit_message(
-                f"SSH block in node‑group '{gname}' missing: {', '.join(missing_ssh)}"
+                f"SSH block in node-group '{gname}' missing: {', '.join(missing_ssh)}"
             )
 
         # backrest (optional but validated if present)
@@ -2246,24 +2246,24 @@ def json_validate_add_node(data):
             missing_br = backrest_required - set(br.keys())
             if missing_br:
                 util.exit_message(
-                    f"pgBackRest block in node‑group '{gname}' missing: {', '.join(missing_br)}"
+                    f"pgBackRest block in node-group '{gname}' missing: {', '.join(missing_br)}"
                 )
 
-            # ensure values are non‑empty
+            # ensure values are non-empty
             for k in backrest_required:
                 if not str(br[k]).strip():
                     util.exit_message(
-                        f"pgBackRest key '{k}' in node‑group '{gname}' cannot be empty."
+                        f"pgBackRest key '{k}' in node-group '{gname}' cannot be empty."
                     )
 
             # verify repo1_type is valid
             if br["repo1_type"] not in valid_repo1_types:
                 util.exit_message(
-                    f"Invalid repo1_type '{br['repo1_type']}' in node‑group '{gname}'. "
+                    f"Invalid repo1_type '{br['repo1_type']}' in node-group '{gname}'. "
                     f"Allowed: {', '.join(valid_repo1_types)}"
                 )
 
-    util.message("✔ add‑node JSON structure is valid.", "success")
+    util.message("✔ add-node JSON structure is valid.", "success")
 
 def remove_node(cluster_name, node_name):
     """

--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -1443,25 +1443,25 @@ def init(cluster_name, install=True):
             cmd_create_stanza = (
                 f"cd {node['path']}/pgedge && "
                 f"./pgedge backrest command stanza-create "
-                f"--stanza '{stanza}' "
-                f"--pg1-path '{pg1_path}' "
-                f"--repo1-cipher-type {repo1_cipher_type} "
-                f"--pg1-port {port} "
-                f"--repo1-path {repo1_path}"
+                f"--stanza='{stanza}' "
+                f"--pg1-path='{pg1_path}' "
+                f"--repo1-cipher-type={repo1_cipher_type} "
+                f"--pg1-port={port} "
+                f"--repo1-path={repo1_path}"
             )
             run_cmd(cmd_create_stanza, node=node, message=f"Creating pgBackRest stanza '{stanza}'", verbose=verbose)
     
             # -- Step 7: Initiate a full backup using pgBackRest (again, passing the port)
             backrest_backup_args = (
-                f"--repo1-path {repo1_path} "
-                f"--stanza {stanza} "
-                f"--pg1-path {pg1_path} "
-                f"--repo1-type {repo1_type} "
-                f"--log-level-console {log_level_console} "
-                f"--pg1-port {port} "
-                f"--db-socket-path /tmp "
-                f"--repo1-cipher-type {repo1_cipher_type} "
-                f"--repo1-retention-full {repo1_retention_full} "
+                f"--repo1-path={repo1_path} "
+                f"--stanza={stanza} "
+                f"--pg1-path={pg1_path} "
+                f"--repo1-type={repo1_type} "
+                f"--log-level-console={log_level_console} "
+                f"--pg1-port={port} "
+                f"--db-socket-path=/tmp "
+                f"--repo1-cipher-type={repo1_cipher_type} "
+                f"--repo1-retention-full={repo1_retention_full} "
                 f"--type=full"
             )
             cmd_create_backup = f"cd {node['path']}/pgedge && ./pgedge backrest command backup '{backrest_backup_args}'"
@@ -1550,7 +1550,7 @@ def add_node(
     pg = db_settings["pg_version"]
     pgV = f"pg{pg}"
     verbose = cluster_data.get("log_level", "info")
-    
+
     # Load and validate the target node JSON
     target_node_file = f"{target_node}.json"
     if not os.path.isfile(target_node_file):
@@ -1600,7 +1600,6 @@ def add_node(
             "os_user": os_user,
             "ssh_key": ssh_key,
         }
-
 
     if "public_ip" not in target_node_data and "private_ip" not in target_node_data:
         util.exit_message(
@@ -1729,11 +1728,11 @@ def add_node(
         cmd_create_stanza_source = (
             f"cd {source_node_data['path']}/pgedge && "
             f"./pgedge backrest command stanza-create "
-            f"--stanza '{source_stanza}' "
-            f"--pg1-path '{source_pg1_path}' "
-            f"--repo1-cipher-type {source_repo1_cipher_type} "
-            f"--pg1-port {source_port} "
-            f"--repo1-path {source_repo1_path}"
+            f"--stanza='{source_stanza}' "
+            f"--pg1-path='{source_pg1_path}' "
+            f"--repo1-cipher-type={source_repo1_cipher_type} "
+            f"--pg1-port={source_port} "
+            f"--repo1-path={source_repo1_path}"
         )
         run_cmd(
             cmd_create_stanza_source,
@@ -1743,15 +1742,15 @@ def add_node(
         )
         # Step 7: Initiate a full backup using pgBackRest (again, passing the port)
         backrest_backup_args_source = (
-            f"--repo1-path {source_repo1_path} "
-            f"--stanza {source_stanza} "
-            f"--pg1-path {source_pg1_path} "
-            f"--repo1-type {source_repo1_type} "
-            f"--log-level-console {source_log_level_console} "
-            f"--pg1-port {source_port} "
-            f"--db-socket-path /tmp "
-            f"--repo1-cipher-type {source_repo1_cipher_type} "
-            f"--repo1-retention-full {source_repo1_retention_full} "
+            f"--repo1-path={source_repo1_path} "
+            f"--stanza={source_stanza} "
+            f"--pg1-path={source_pg1_path} "
+            f"--repo1-type={source_repo1_type} "
+            f"--log-level-console={source_log_level_console} "
+            f"--pg1-port={source_port} "
+            f"--db-socket-path=/tmp "
+            f"--repo1-cipher-type={source_repo1_cipher_type} "
+            f"--repo1-retention-full={source_repo1_retention_full} "
             f"--type=full"
         )
         cmd_create_backup_source = f"cd {source_node_data['path']}/pgedge && ./pgedge backrest command backup '{backrest_backup_args_source}'"
@@ -1830,15 +1829,24 @@ def add_node(
     message = f"Removing old data directory"
     run_cmd(cmd, target_node_data, message=message, verbose=verbose)
 
-    args = f"--repo1-path {repo1_path} --repo1-cipher-type {source_repo1_cipher_type} --type standby "
+    restore_args = (
+        f'--cmd="pgbackrest --repo1-cipher-type={source_repo1_cipher_type}" '
+        f"--stanza={source_stanza} "
+        f"--pg1-path={target_node_data['path']}/pgedge/data/{pgV} "
+        f"--repo1-path={repo1_path} "
+        f"--repo1-cipher-type={source_repo1_cipher_type} "
+        f"--repo1-type={source_repo1_type} "
+        "--type=standby "
+    )
+
     if backup_id:
-        args += f"--set={backup_id} "
+        restore_args.append(f"--set={backup_id}")
 
     cmd = (
         f'{target_node_data["path"]}/pgedge/pgedge backrest command restore '
-        f"--repo1-type={source_repo1_type} --stanza={source_stanza} "
-        f'--pg1-path={target_node_data["path"]}/pgedge/data/{pgV} {args}'
+        f"'{restore_args}'"
     )
+
     message = f"Restoring backup"
     run_cmd(cmd, target_node_data, message=message, verbose=verbose)
 
@@ -1846,15 +1854,15 @@ def add_node(
     pgc = f"{pgd}/postgresql.conf"
     log_directory = f'{target_node_data["path"]}/pgedge/data/logs/{pgV}'
 
-    cmd = f"echo \"ssl_cert_file='{pgd}/server.crt'\" >> {pgc}"
+    cmd = f"sed -i \"/^ssl_cert_file/d\" {pgc} && echo \"ssl_cert_file = '{pgd}/server.crt'\" >> {pgc}"
     message = f"Setting ssl_cert_file"
     run_cmd(cmd, target_node_data, message=message, verbose=verbose)
 
-    cmd = f"echo \"ssl_key_file='{pgd}/server.key'\" >> {pgc}"
+    cmd = f"sed -i \"/^ssl_key_file/d\" {pgc} && echo \"ssl_key_file = '{pgd}/server.key'\" >> {pgc}"
     message = f"Setting ssl_key_file"
     run_cmd(cmd, target_node_data, message=message, verbose=verbose)
 
-    cmd = f"echo \"log_directory='{log_directory}'\" >> {pgc}"
+    cmd = f"sed -i \"/^log_directory/d\" {pgc} && echo \"log_directory = '{log_directory}'\" >> {pgc}"
     message = f"Setting log_directory"
     run_cmd(cmd, target_node_data, message=message, verbose=verbose)
 
@@ -1890,7 +1898,7 @@ def add_node(
     cmd = f"{target_node_data['path']}/pgedge/pgedge psql '{sql_cmd}' {db_name}"
     message = f"Promoting standby to primary"
     run_cmd(cmd, target_node_data, message=message, verbose=verbose)
-    
+
     for mdb in db:
         sql_cmd = "SELECT sub_name FROM spock.subscription"
         cmd = f"{target_node_data['path']}/pgedge/pgedge psql '{sql_cmd}' {mdb['db_name']}"
@@ -2007,7 +2015,7 @@ def add_node(
         cmd, node=target_node_data, message=message, verbose=verbose, capture_output=True
     )
     print(f"\n{result.stdout}")
-    
+
     # A subsequent restart will be needed to apply the changes
     # This will occur in the next section when pgBackrest is configured or removed
     # Cleanup restore remnants by unsetting restore_command on target node
@@ -2015,7 +2023,7 @@ def add_node(
         'ALTER SYSTEM RESET restore_command'
     )
     cmd = f"{target_node_data['path']}/pgedge/pgedge psql '{sql_cmd}' {db_name}"
-    message = "Unsetting restore_command on target node"
+    message = "Unsetting restore_command"
     run_cmd(cmd, node=target_node_data, message=message, verbose=verbose)
 
     # Cleanup replica configuration
@@ -2024,7 +2032,7 @@ def add_node(
         f"./pgedge backrest cleanup-replica "
         f"--pg1-path {target_node_data['path']}/pgedge/data/{pgV} "
     )
-    run_cmd(cmd, node=target_node_data, message="Cleaning up replica configuration on target node", verbose=verbose)
+    run_cmd(cmd, node=target_node_data, message="Cleaning up replica configuration", verbose=verbose)
 
     target_backrest_cfg = target_node_data.get("backrest", {})
     if target_backrest_cfg:
@@ -2112,11 +2120,11 @@ def add_node(
         cmd_create_stanza_target = (
             f"cd {target_pgedge_dir} && "
             f"./pgedge backrest command stanza-create "
-            f"--stanza '{target_stanza}' "
-            f"--pg1-path '{target_pg1_path}' "
-            f"--repo1-cipher-type {target_repo1_cipher_type} "
-            f"--pg1-port {target_pg1_port} "
-            f"--repo1-path {target_repo1_path}"
+            f"--stanza='{target_stanza}' "
+            f"--pg1-path='{target_pg1_path}' "
+            f"--repo1-cipher-type={target_repo1_cipher_type} "
+            f"--pg1-port={target_pg1_port} "
+            f"--repo1-path={target_repo1_path}"
         )
         run_cmd(
             cmd=cmd_create_stanza_target,
@@ -2127,15 +2135,15 @@ def add_node(
 
         # Create a full backup using pgBackRest
         backrest_backup_args_target = (
-            f"--repo1-path {target_repo1_path} "
-            f"--stanza {target_stanza} "
-            f"--pg1-path {target_pg1_path} "
-            f"--repo1-type {target_repo1_type} "
-            f"--log-level-console {target_log_level_console} "
-            f"--pg1-port {target_pg1_port} "
-            f"--db-socket-path /tmp "
-            f"--repo1-cipher-type {target_repo1_cipher_type} "
-            f"--repo1-retention-full {target_repo1_retention_full} "
+            f"--repo1-path={target_repo1_path} "
+            f"--stanza={target_stanza} "
+            f"--pg1-path={target_pg1_path} "
+            f"--repo1-type={target_repo1_type} "
+            f"--log-level-console={target_log_level_console} "
+            f"--pg1-port={target_pg1_port} "
+            f"--db-socket-path=/tmp "
+            f"--repo1-cipher-type={target_repo1_cipher_type} "
+            f"--repo1-retention-full={target_repo1_retention_full} "
             f"--type=full"
         )
         cmd_create_backup_target = (
@@ -2175,7 +2183,7 @@ def add_node(
     cluster_data["update_date"] = datetime.datetime.now().astimezone().isoformat()
 
     write_cluster_json(cluster_name, cluster_data)
-    
+
 
 def json_validate_add_node(data):
     """

--- a/cli/scripts/install.py
+++ b/cli/scripts/install.py
@@ -3,7 +3,7 @@
 
 import sys, os, tarfile, platform
 
-VER = "25.0.0-alpha3"
+VER = "25.0.0-alpha4"
 REPO = os.getenv("REPO", "https://pgedge-upstream.s3.amazonaws.com/REPO")
 
 if sys.version_info < (3, 9):

--- a/cli/scripts/util.py
+++ b/cli/scripts/util.py
@@ -4,7 +4,7 @@
 import os
 import time
 
-MY_VERSION = "25.0.0-alpha3"
+MY_VERSION = "25.0.0-alpha4"
 MY_CODENAME = ""
 
 DEFAULT_PG = "16"

--- a/devel/setup/Dockerfile.rocky810
+++ b/devel/setup/Dockerfile.rocky810
@@ -7,8 +7,9 @@ USER root
 
 ENV install="dnf install -y --allowerasing"
 RUN $install dnf-plugins-core
+RUN $install epel-release
 RUN $install python3 python3-pip git wget curl pigz which zip sqlite
-RUN $install openssh-server systemd sudo
+RUN $install openssh-server systemd sudo inotify-tools lsof
 
 RUN useradd build  -U -m -d /home/build  \
     && echo "build  ALL=(ALL)  NOPASSWD: ALL" >> /etc/sudoers

--- a/devel/setup/Dockerfile.rocky95
+++ b/devel/setup/Dockerfile.rocky95
@@ -8,7 +8,7 @@ USER root
 ENV install="dnf install -y --allowerasing"
 RUN $install dnf-plugins-core
 RUN $install python3 python3-pip git wget curl pigz which zip sqlite
-RUN $install openssh-server systemd sudo
+RUN $install openssh-server systemd sudo inotify-tools lsof
 
 RUN useradd build  -U -m -d /home/build  \
     && echo "build  ALL=(ALL)  NOPASSWD: ALL" >> /etc/sudoers

--- a/devel/setup/Dockerfile.rocky95
+++ b/devel/setup/Dockerfile.rocky95
@@ -7,6 +7,7 @@ USER root
 
 ENV install="dnf install -y --allowerasing"
 RUN $install dnf-plugins-core
+RUN $install epel-release
 RUN $install python3 python3-pip git wget curl pigz which zip sqlite
 RUN $install openssh-server systemd sudo inotify-tools lsof
 

--- a/devel/setup/compose/Dockerfile.node.rocky95
+++ b/devel/setup/compose/Dockerfile.node.rocky95
@@ -31,7 +31,7 @@ RUN chmod 700 /home/pgedge/.ssh/
 RUN sudo chown pgedge:pgedge /home/pgedge/.ssh/id_rsa
 RUN sudo chmod 600 /home/pgedge/.ssh/id_rsa
 
-RUN sed -i '1iexport PGBACKREST_REPO1_CIPHER_PASS=Really_s3cure_password' ~/.bashrc
+RUN sed -i '1iexport PGBACKREST_REPO1_CIPHER_PASS=supersecret' ~/.bashrc
 
 USER root
 EXPOSE 22

--- a/devel/setup/compose/Dockerfile.node.ubuntu2204
+++ b/devel/setup/compose/Dockerfile.node.ubuntu2204
@@ -31,7 +31,7 @@ RUN chmod 700 /home/pgedge/.ssh/
 RUN sudo chown pgedge:pgedge /home/pgedge/.ssh/id_rsa
 RUN sudo chmod 600 /home/pgedge/.ssh/id_rsa
 
-RUN echo 'export PGBACKREST_REPO1_CIPHER_PASS=Really_s3cure_password' >> ~/.bashrc
+RUN echo 'export PGBACKREST_REPO1_CIPHER_PASS=supersecret' >> ~/.bashrc
 
 USER root
 EXPOSE 22

--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,5 @@
-hubV=25.0.0-alpha3
-hubVV=25.0.0-alpha3
+hubV=25.0.0-alpha4
+hubVV=25.0.0-alpha4
 
 aceV=$hubV
 kirkV=$hubV

--- a/src/backrest/backrest.py
+++ b/src/backrest/backrest.py
@@ -7,8 +7,6 @@ import json
 import sys
 from datetime import datetime
 from tabulate import tabulate
-import yaml
-from typing import Optional
 
 def pgV():
     """Return the first found PostgreSQL version (v14 thru v17)."""
@@ -183,6 +181,7 @@ def backup(stanza, type="full", verbose=True):
         )
     else:
         util.message(f"Successfully completed {type} backup for stanza '{stanza}'")
+
 def restore(stanza, data_dir=None, backup_label=None, recovery_target_time=None, verbose=True):
     """Restore a database cluster to a specified state."""
     config = fetch_config()
@@ -254,6 +253,19 @@ def pitr(stanza, data_dir=None, recovery_target_time=None, verbose=True):
     if restore(stanza, data_dir, None, recovery_target_time, verbose):
         _configure_pitr(stanza, data_dir, recovery_target_time)
 
+def cleanup_replica(pg1_path):
+    """Cleanup the replica configuration and restore remnants."""
+    conf_file = os.path.join(pg1_path, "postgresql.conf")
+    changes = {
+        "hot_standby": "off",
+        "primary_conninfo": "",
+        "archive_command": "",
+        "archive_mode": "off"
+    }
+    for key, value in changes.items():
+        change_pgconf_keyval(conf_file, key, value)
+
+
 def _configure_pitr(stanza, pg_data_dir=None, recovery_target_time=None):
     """Configure PostgreSQL for point-in-time recovery."""
     config = fetch_config()
@@ -264,7 +276,6 @@ def _configure_pitr(stanza, pg_data_dir=None, recovery_target_time=None):
     config_file = os.path.join(pg_data_dir, "postgresql.conf")
     changes = {
         "port": "5433",
-        "log_directory": os.path.join(pg_data_dir, "log"),
         "archive_command": "",
         "archive_mode": "off",
         "hot_standby": "on",
@@ -288,6 +299,7 @@ def change_pgconf_keyval(config_path, key, value):
                 file.write(line)
         if not key_found:
             file.write(f"{key} = '{value}'\n")
+
 def create_replica(stanza, data_dir=None, backup_label=None, verbose=True):
     """Create a replica by restoring from a backup."""
     if restore(stanza, data_dir, backup_label, verbose=verbose):
@@ -303,7 +315,6 @@ def configure_replica(stanza, pg1_path, pg1_host, pg1_port, pg1_user):
         "hot_standby": "on",
         "primary_conninfo": primary_conninfo,
         "port": pg1_port,
-        "log_directory": os.path.join(pg1_path, "log"),
         "archive_command": "cd .",
         "archive_mode": "on"
     }
@@ -518,12 +529,13 @@ if __name__ == "__main__":
         "pitr": pitr,
         "create-stanza": create_stanza,
         "create-replica": create_replica,
-        "configure_replica": configure_replica,
+        "configure-replica": configure_replica,
         "list-backups": list_backups,
         "show-config": show_config,
         "write-config": write_config,
         "update-config": update_config, 
-        "set_hbaconf": modify_hba_conf,
-        "set_postgresqlconf": modify_postgresql_conf,
+        "set-hbaconf": modify_hba_conf,
+        "set-postgresqlconf": modify_postgresql_conf,
+        "cleanup-replica": cleanup_replica,
         "command": run_external_command,
     })

--- a/src/backrest/backrest.py
+++ b/src/backrest/backrest.py
@@ -92,7 +92,7 @@ def create_stanza(stanza, verbose=True):
 
     # Modify postgresql.conf to ensure archiving is on
     modify_postgresql_conf(
-        stanza, config['pg1-path'], config['repo1-path'], config['repo1-type']
+        stanza, config['pg1-path'], config['repo1-path'], config['repo1-type'], config['repo1-cipher-type']
     )
     # Modify pg_hba.conf for replication, if needed
     modify_hba_conf()
@@ -407,12 +407,12 @@ def modify_hba_conf():
     }]
     util.update_pg_hba_conf(pgV(), new_rules)
 
-def modify_postgresql_conf(stanza, pg1_path, repo1_path, repo1_type):
+def modify_postgresql_conf(stanza, pg1_path, repo1_path, repo1_type, repo1_cipher_type="aes-256-cbc"):
     """Modify 'postgresql.conf' to integrate with pgbackrest."""
     aCmd = (
         f"pgbackrest --stanza={stanza} --pg1-path={pg1_path} "
         f"--repo1-type={repo1_type} --repo1-path={repo1_path} "
-        f"--repo1-cipher-type=aes-256-cbc archive-push %p"
+        f"--repo1-cipher-type={repo1_cipher_type} archive-push %p"
     )
     util.change_pgconf_keyval(pgV(), "archive_command", aCmd, p_replace=True)
     util.change_pgconf_keyval(pgV(), "archive_mode", "on", p_replace=True)

--- a/src/backrest/backrest.py
+++ b/src/backrest/backrest.py
@@ -314,7 +314,6 @@ def configure_replica(stanza, pg1_path, pg1_host, pg1_port, pg1_user):
     changes = {
         "hot_standby": "on",
         "primary_conninfo": primary_conninfo,
-        "port": pg1_port,
         "archive_command": "cd .",
         "archive_mode": "on"
     }

--- a/src/backrest/install-backrest.py
+++ b/src/backrest/install-backrest.py
@@ -2,12 +2,7 @@
 #     Copyright (c)  2022-2025 PGEDGE  #
 
 import os
-import subprocess
-import time
 import sys
-import getpass
-from crontab import CronTab
-import subprocess
 import util
 
 thisDir = os.path.dirname(os.path.realpath(__file__))
@@ -36,6 +31,7 @@ def osSys(p_input, p_display=False):
         util.message("# " + p_input)
     rc = os.system(p_input)
     return rc
+
 def configure_backup_settings():
     """Configure and return the pgBackRest settings."""
     stanza = "pg16"
@@ -93,94 +89,12 @@ def setup_pgbackrest_links():
     osSys("sudo mkdir -p -m 770 /var/lib/pgbackrest")
     osSys(f"sudo chown {usrUsr} -R /var/lib/pgbackrest")
 
-def modify_hba_conf():
-  new_rules = [
-      {
-            "type": "host",
-            "database": "replication",
-            "user": "all",
-            "address": "127.0.0.1/0",
-            "method": "trust"
-      }
-  ]
-  util.update_pg_hba_conf(pgV(), new_rules)
-
-def create_or_update_job(crontab_lines, job_comment, detailed_comment, new_job):
-    job_identifier = f"# {job_comment}"
-    detailed_comment_line = f"# {detailed_comment}\n"
-    job_exists = False
-
-    for i, line in enumerate(crontab_lines):
-        if job_identifier in line:
-            crontab_lines[i] = job_identifier + "\n"
-            if i + 1 < len(crontab_lines):
-                crontab_lines[i + 1] = detailed_comment_line
-                crontab_lines[i + 2] = new_job
-            job_exists = True
-            break
-
-    if not job_exists:
-        crontab_lines.extend([job_identifier + "\n", detailed_comment_line, new_job])
-
-def define_cron_job():
-    stanza = util.get_value("BACKUP", "stanza")
-    full_backup_command = f"pgbackrest --stanza={stanza} --type=full backup"
-    incr_backup_command = f"pgbackrest --stanza={stanza} --type=incr backup"
-    expire_backup_command = f"pgbackrest --stanza={stanza} expire"
-
-    run_as_user = 'root'
-
-    # Crontab entries with detailed comments
-    full_backup_cron = f"0 1 * * * {run_as_user} {full_backup_command}\n"
-    incr_backup_cron = f"0 * * * * {run_as_user} {incr_backup_command}\n"
-    expire_backup_cron = f"30 1 * * * {run_as_user} {expire_backup_command}\n"
-
-    # Detailed comments for each job
-    full_backup_comment = "Performs a full backup daily at 1 AM."
-    incr_backup_comment = "Performs an incremental backup every hour."
-    expire_backup_comment = "Manages backup retention, expiring old backups at 1:30 AM daily."
-
-    system_crontab_path = "/etc/crontab"
-    backrest_crontab_path = "backrest.crontab"
-
-    with open(system_crontab_path, 'r') as file:
-        existing_crontab = file.readlines()
-
-    create_or_update_job(existing_crontab, "FullBackup", full_backup_comment, full_backup_cron)
-    create_or_update_job(existing_crontab, "IncrementalBackup", incr_backup_comment, incr_backup_cron)
-    create_or_update_job(existing_crontab, "ExpireBackup", expire_backup_comment, expire_backup_cron)
-
-    with open(backrest_crontab_path, 'w') as file:
-        file.writelines(existing_crontab)
-
-    osSys(f"sudo cat {backrest_crontab_path} | sudo tee {system_crontab_path} > /dev/null", False)
-
-def fetch_backup_config():
-    """Fetch and return the pgBackRest configuration from system settings."""
-    config = {}
-    params = [
-        "stanza", "restore_path", "backup-type", "repo1-retention-full",
-        "repo1-retention-full-type", "repo1-path", "repo1-host-user",
-        "repo1-host", "repo1-cipher-type", "repo1-cipher-pass", "repo1-s3-bucket",
-        "repo1-s3-key-secret", "repo1-s3-key", "repo1-s3-region", "repo1-s3-endpoint",
-        "log-level-console", "repo1-type", "process-max", "compress-level",
-        "pg1-path", "pg1-user", "pg1-database", "db-socket-path", "pg1-port",
-        "pg1-host"
-    ]
-
-    # Fetch all parameters
-    for param in params:
-        config[param] = util.get_value("BACKUP", param)
-    
-    return config
-
 def print_header(header):
     bold_start = "\033[1m"
     bold_end = "\033[0m"
     print(bold_start + "##### " + header + " #####"+ bold_end)
 
 def main():
-    stanza = pgV()
     if os.path.isdir(f"/var/lib/pgbackrest/"):
         util.message("/var/lib/pgbackrest directory already exists")
     

--- a/src/conf/versions.sql
+++ b/src/conf/versions.sql
@@ -1,7 +1,7 @@
 
 DROP TABLE IF EXISTS hub;
 CREATE TABLE hub(v TEXT NOT NULL PRIMARY KEY, c TEXT NOT NULL, d TEXT NOT NULL);
-INSERT INTO hub VALUES ('25.0.0-alpha3', 'Constellation',  '20250421');
+INSERT INTO hub VALUES ('25.0.0-alpha4', 'Constellation',  '20250421');
 
 DROP VIEW  IF EXISTS v_versions;
 DROP VIEW  IF EXISTS v_products;


### PR DESCRIPTION
- Resolved an issue where recovery.signal would remain after the add-node process completed by setting `--type=standby` in the pgBackRest restore
- Fixed an issue where cipher-type would not be set in the restore_command due to how pgBackRest generates the command, resulting in the inability to restore WAL from the repository (if needed)
- Refactored add-node process to cleanly refer to source and target node
- Simplified pgbackrest reconfguration logic for the source / target nodes
- Added a backrest cleanup-replica command that ensures the newly added node does not have lingering configuration from the add node process
- Ensured the restore_command is unset on the target node after the add node process completes
- Fixed an issue where the pgBackRest yaml was rewritten to all nodes during add-node. It will now only be written to the target node during reconfiguration if pgBackRest should be configured on the target node
- Removed logic that set S3 environment variables on the target node. This is documented as a prerequisite and will be handled by the user
- Removed unused functions in backrest.py
- Fixed an issue where repo-type S3 would not have it's repository configured
- Fixed an issue where cipher-type=none was not respected
- Fixed an issue where ssl_cert_file, ssl_key_file, and log_directory would not be properly configured on the target node
- Removed code that set shared_preload_libraries on the target node - this is already set during the restore
- Fixed an issue where add-node would use public ips for replication connections, even if private ips were provided
- Add polling logic to verify postgres comes out of recovery during add node

Resolves PLAT-53, PLAT-34, PLAT-45