### PR TITLE
Added custom help flag and environment variable overrides to db create function

### DIFF
--- a/cli/scripts/db.py
+++ b/cli/scripts/db.py
@@ -1,27 +1,63 @@
 
 #  Copyright 2022-2025 PGEDGE  All rights reserved. #
 
-
 import os
 import sys
 import platform
 import subprocess
 import json
-
 import util
 import fire
 
-
-def create(db=None, User=None, Passwd=None, pg=None, spock=None):
+def create(db=None, User=None, Passwd=None, pg=None, spock=None, help=False):
     """
-    Create a pg db with spock components installed into it.
-
-
-     Usage:
-         To create a database owned by a specific user
-            db create -d <db> -U <usr> -P <passwd>
-
+     Create a database owned by a specific user
     """
+
+    if help:
+        print(
+"""
+Create a pg db with spock components installed into it.
+
+Usage:
+    db create --db <db> --User <usr> --Passwd <passwd> --pg=<pg> --spock <spock>
+
+Flags:
+  -d, --db        Name of the database to create
+  -U, --User      Owner user of the new database
+  -P, --Passwd    Password for the new user 
+      --pg        Postgres version to use
+  -s, --spock     Spock version to install
+
+"""
+        )
+        return
+
+    new_argv = []
+    for arg in sys.argv:
+
+        if arg == '-U':
+            new_argv.append('--User')
+        elif arg.startswith('-U') and not arg.startswith('-User'):
+            new_argv.append('--User=' + arg[2:])
+
+        elif arg == '-P':
+            new_argv.append('--Passwd')
+        elif arg.startswith('-P') and not arg.startswith('-Passwd'):
+            new_argv.append('--Passwd=' + arg[2:])
+        else:
+            new_argv.append(arg)
+    sys.argv[:] = new_argv
+    
+    pgeUser = os.getenv("pgeUser", "")
+    if pgeUser and User is None:
+        util.message(f"over-riding 'User' with ENV pgeUser={pgeUser}", "debug")
+        User = pgeUser
+
+    pgePasswd = os.getenv("pgePasswd", "")
+    if pgePasswd and Passwd is None:
+        util.message(f"over-riding 'Passwd' with ENV pgePasswd={pgePasswd}", "debug")
+        Passwd = pgePasswd
 
     util.message(f"db.create(db={db}, User={User}, Passwd={Passwd}, pg={pg}, spock={spock})", "debug")
 

--- a/cli/scripts/db.py
+++ b/cli/scripts/db.py
@@ -16,38 +16,23 @@ def create(db=None, User=None, Passwd=None, pg=None, spock=None, help=False):
 
     if help:
         print(
-"""
-Create a pg db with spock components installed into it.
+    """
+    Create a pg db with spock components installed into it.
 
-Usage:
-    db create --db <db> --User <usr> --Passwd <passwd> --pg=<pg> --spock <spock>
+    Usage:
+        ./pgedge db create --db <db> --User <usr> --Passwd <passwd> --pg=<pg> --spock <spock>
 
-Flags:
-  -d, --db        Name of the database to create
-  -U, --User      Owner user of the new database
-  -P, --Passwd    Password for the new user 
-      --pg        Postgres version to use
-  -s, --spock     Spock version to install
+    Flags:
+    -d, --db        Name of the database to create
+    -U, --User      Owner user of the new database
+    -P, --Passwd    Password for the new user 
+        --pg        Postgres version to use
+    -s, --spock     Spock version to install
 
-"""
+    """
         )
         return
 
-    new_argv = []
-    for arg in sys.argv:
-
-        if arg == '-U':
-            new_argv.append('--User')
-        elif arg.startswith('-U') and not arg.startswith('-User'):
-            new_argv.append('--User=' + arg[2:])
-
-        elif arg == '-P':
-            new_argv.append('--Passwd')
-        elif arg.startswith('-P') and not arg.startswith('-Passwd'):
-            new_argv.append('--Passwd=' + arg[2:])
-        else:
-            new_argv.append(arg)
-    sys.argv[:] = new_argv
     
     pgeUser = os.getenv("pgeUser", "")
     if pgeUser and User is None:


### PR DESCRIPTION
1. Introducing a --help flag that hijacks Fire’s default help output, allowing a fully custom usage message.
2. Adding support for the legacy -U shorthand, normalizing it to the --User parameter automatically.