### PR TITLE
[ACE-45] Cleanup views on table-diff failures

### DIFF
--- a/cli/scripts/ace.py
+++ b/cli/scripts/ace.py
@@ -1978,6 +1978,7 @@ def handle_task_exception(task, task_context):
     if (
         isinstance(task, TableDiffTask)
         and getattr(task, "table_filter", False)
+        and task.table_filter is not None
         and task.table_filter != ""
     ):
         view_schema = task.fields.l_schema
@@ -2003,14 +2004,10 @@ def handle_task_exception(task, task_context):
                 _, conn = task.connection_pool.get_cluster_node_connection(
                     node_info,
                     task.cluster_name,
-                    invoke_method=getattr(task, "invoke_method", "cli"),
+                    invoke_method=task.invoke_method,
                     client_role=(
-                        getattr(task, "client_role", None)
-                        if (
-                            hasattr(config, "USE_CERT_AUTH")
-                            and config.USE_CERT_AUTH
-                            and getattr(task, "invoke_method", None) == "api"
-                        )
+                        task.client_role
+                        if config.USE_CERT_AUTH and task.invoke_method == "api"
                         else None
                     ),
                 )

--- a/cli/scripts/ace.py
+++ b/cli/scripts/ace.py
@@ -2013,14 +2013,13 @@ def handle_task_exception(task, task_context):
                 )
 
                 if conn:
-                    drop_view_sql = sql.SQL(
-                        "DROP VIEW IF EXISTS {schema}.{view}"
-                    ).format(
-                        schema=sql.Identifier(view_schema),
-                        view=sql.Identifier(view_name_to_drop),
-                    )
                     with conn.cursor() as cur:
-                        cur.execute(drop_view_sql)
+                        cur.execute(
+                            sql.SQL("DROP VIEW IF EXISTS {schema}.{view}").format(
+                                schema=sql.Identifier(view_schema),
+                                view=sql.Identifier(view_name_to_drop),
+                            )
+                        )
                     conn.commit()
                     msg = (
                         "Successfully dropped view "

--- a/cli/scripts/ace_core.py
+++ b/cli/scripts/ace_core.py
@@ -437,7 +437,18 @@ def table_diff(td_task: TableDiffTask, skip_all_checks: bool = False):
     """Efficiently compare tables across cluster using checksums and blocks of rows"""
 
     if not skip_all_checks:
-        td_task = ace.table_diff_checks(td_task, skip_validation=True)
+        try:
+            td_task = ace.table_diff_checks(td_task, skip_validation=True)
+        except Exception as e_checks:
+            context = {
+                "total_rows": 0,
+                "mismatch": False,
+                "errors": [
+                    f"Error during pre-flight checks for table_diff: {str(e_checks)}"
+                ]
+            }
+            ace.handle_task_exception(td_task, context)
+            raise
 
     simple_primary_key = True
     if len(td_task.fields.key.split(",")) > 1:
@@ -795,8 +806,9 @@ def table_diff(td_task: TableDiffTask, skip_all_checks: bool = False):
                 ),
             )
             conn.execute(
-                sql.SQL("DROP VIEW IF EXISTS {view_name}").format(
-                    view_name=sql.Identifier(f"{td_task.scheduler.task_id}_view"),
+                sql.SQL("DROP VIEW IF EXISTS {schema}.{view_name}").format(
+                    schema=sql.Identifier(td_task.fields.l_schema),
+                    view_name=sql.Identifier(td_task.fields.l_table),
                 )
             )
             conn.commit()


### PR DESCRIPTION
* Fixes a bug when the `table-filter` option is used and when the cluster has `auto_ddl` enabled.
* Cleans up views created by `table-filter` if table-diff errors out for some reason.