### PR TITLE
Add support for current daily builds with latest Spock

### DIFF
--- a/.github/workflows/current-amd8-daily-build-devel.yml
+++ b/.github/workflows/current-amd8-daily-build-devel.yml
@@ -1,0 +1,271 @@
+name: Current Daily Build Devel - amd8
+
+# Define default environment variables for carrying defaults at the top for easy modification
+env:
+  DEFAULT_CLI_BRANCH: "REL25_01"      # Default CLI branch for scheduled runs
+  DEFAULT_MODE: "current"             # Always "current" for this workflow
+  DEFAULT_COMPONENT: "spock50"        # Default spock component name
+  DEFAULT_BRANCH: "main"              # Default branch for the spock component
+  DEFAULT_CLEAN_FLAG: "false"         # Default clean flag for scheduled runs
+
+# Triggers: Scheduled at 12:00 AM UTC and manual workflow dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      cli_branch:
+        description: "Select the CLI branch to build from (e.g. REL25_01)"
+        required: true
+        default: "REL25_01"
+        type: choice
+        options:
+          - REL25_01
+          - REL24_10
+
+      component:
+        description: "Spock in-dev component to additionally build (e.g. spock50)"
+        required: true
+        default: "spock50"
+        type: string
+
+      branch:
+        description: "Branch to use for spock component (e.g. main)"
+        required: true
+        default: "main"
+        type: string
+
+      prefix_selector:
+        description: "Choose S3 subdirectory strategy (default: MMDD, or custom)"
+        required: true
+        default: "default"
+        type: choice
+        options:
+          - default
+          - custom
+
+      custom_prefix:
+        description: "If 'custom' selected above, provide sub-directory name"
+        required: false
+        type: string
+
+      clean_prefix:
+        description: "Clean the repo sub-directory before copying packages"
+        required: false
+        type: choice
+        options:
+          - "false"
+          - "true"
+        default: "false"
+
+  schedule:
+    - cron: "0 0 * * *"  # 12:00 AM UTC, 8pm EST.. 1 hour after stable build at 11:00 PM UTC
+
+jobs:
+  build-current-amd8:
+    runs-on: [self-hosted, amd8]
+
+    steps:
+      # Resolve parameters (scheduled vs manual) and set up timestamped log directory
+      - name: Set build parameters and logfile
+        id: vars
+        run: |
+          source ~/.bashrc
+
+          echo "Resolving build parameters for CURRENT mode workflow..."
+
+          TODAY=$(date +%m%d)
+          RUNNER_NAME="${{ runner.name }}"
+
+          # Create timestamped log directory with mmddhhmmss format
+          TIMESTAMP=$(date +%m%d%H%M%S)
+          LOG_DIR="/tmp/current-build-$TIMESTAMP"
+          mkdir -p "$LOG_DIR"
+          echo "Created log directory: $LOG_DIR"
+
+          # Determine parameters based on trigger type
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            # Scheduled run: use defaults
+            PREFIX="$TODAY"
+            CLEAN_FLAG=""
+            SELECTED_CLI_BRANCH="${DEFAULT_CLI_BRANCH}"
+            COMPONENT="${DEFAULT_COMPONENT}"
+            BRANCH="${DEFAULT_BRANCH}"
+            echo "Scheduled run: Prefix=$PREFIX, Component=$COMPONENT, Branch=$BRANCH, Clean flag not set, CLI Branch=$SELECTED_CLI_BRANCH"
+          
+          else
+            # Manual run: process inputs
+            if [[ "${{ inputs.prefix_selector }}" == "default" ]]; then
+              PREFIX="$TODAY"
+              echo "Manual run: Using default prefix: $PREFIX"
+            else
+              # Custom prefix validation
+              if [[ "${{ inputs.prefix_selector }}" == "custom" && -z "${{ inputs.custom_prefix }}" ]]; then
+                echo "Error: Custom prefix selected but no input provided."
+                exit 1
+              fi
+              PREFIX="${{ inputs.custom_prefix }}"
+              echo "Manual run: Using custom prefix: $PREFIX"
+            fi
+
+            # Clean flag handling
+            if [[ "${{ inputs.clean_prefix }}" == "true" ]]; then
+              CLEAN_FLAG="-x"
+              echo "Clean flag is enabled"
+            else
+              CLEAN_FLAG=""
+              echo "Clean flag is disabled"
+            fi
+
+            SELECTED_CLI_BRANCH="${{ inputs.cli_branch }}"
+            COMPONENT="${{ inputs.component }}"
+            BRANCH="${{ inputs.branch }}"
+            echo "Manual run: Component=$COMPONENT, Branch=$BRANCH, CLI Branch=$SELECTED_CLI_BRANCH"
+          fi
+
+          # Set logfile path, matching stable workflow with "current" label
+          LOGFILE_NAME="build_to_devel_current-${RUNNER_NAME}-${TIMESTAMP}.log"
+          LOGFILE_PATH="$LOG_DIR/$LOGFILE_NAME"
+
+          # Export variables
+          echo "RUNNER_NAME=$RUNNER_NAME" >> $GITHUB_ENV
+          echo "MODE=${DEFAULT_MODE}" >> $GITHUB_ENV
+          echo "COMPONENT=$COMPONENT" >> $GITHUB_ENV
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+          echo "PREFIX=$PREFIX" >> $GITHUB_ENV
+          echo "CLEAN_FLAG=$CLEAN_FLAG" >> $GITHUB_ENV
+          echo "LOG_DIR=$LOG_DIR" >> $GITHUB_ENV
+          echo "LOGFILE_PATH=$LOGFILE_PATH" >> $GITHUB_ENV
+          echo "CLI_BRANCH=$SELECTED_CLI_BRANCH" >> $GITHUB_ENV
+
+          echo "Log file will be created at: $LOGFILE_PATH"
+
+      # Display the resolved configuration for debugging
+      - name: Show effective configuration
+        run: |
+          echo "=== CURRENT BUILD WORKFLOW CONFIGURATION ==="
+          echo "Runner: $RUNNER_NAME"
+          echo "Mode: $MODE"
+          echo "Component: $COMPONENT"
+          echo "Branch: $BRANCH"
+          echo "S3 Prefix: $PREFIX"
+          echo "Clean flag: $CLEAN_FLAG"
+          echo "Log directory: $LOG_DIR"
+          echo "Log file path: $LOGFILE_PATH"
+          echo "CLI branch: $CLI_BRANCH"
+          echo "=============================================="
+
+      # Verify environment details and switch to the specified CLI branch
+      - name: Confirm environment and switch CLI branch
+        id: cli_branch_checkout
+        run: |
+          source ~/.bashrc
+          echo "OS info:"
+          cat /etc/os-release
+          echo "Architecture:"
+          arch
+
+          echo "Navigating to CLI directory: $PGE"
+          cd $PGE
+
+          echo "Current branch and status:"
+          git branch
+          git status
+
+          echo "Stashing changes if any..."
+          git stash push -u -m "Temp stash for current build" || true
+
+          echo "Switching to branch: $CLI_BRANCH"
+          git checkout "$CLI_BRANCH" || true
+          echo "Branch checkout completed"
+
+      # Execute the build script and collect artifacts into src/ and bin/
+      - name: Run build and push to devel repo
+        id: build_to_devel
+        run: |
+          source ~/.bashrc
+
+          echo "Launching build script in CURRENT mode..."
+          cd $DEV
+
+          # Construct and run the build command
+          BUILD_CMD="./build_to_devel_2.sh -m $MODE -c $COMPONENT -b $BRANCH -d $PREFIX"
+          if [[ -n "$CLEAN_FLAG" ]]; then
+            BUILD_CMD="$BUILD_CMD $CLEAN_FLAG"
+          fi
+
+          echo "Executing: $BUILD_CMD"
+          $BUILD_CMD > "$LOGFILE_PATH" 2>&1
+          EXIT_CODE=$?
+
+          echo "Build finished with exit code: $EXIT_CODE"
+
+          # Collect artifacts into src/ and bin/
+          echo "Collecting source and binary artifacts..."
+          mkdir -p "$LOG_DIR/src" "$LOG_DIR/bin"
+
+          echo "Copying source files from $SOURCE/${COMPONENT}*"
+          if ls "$SOURCE/${COMPONENT}"* 1> /dev/null 2>&1; then
+            cp "$SOURCE/${COMPONENT}"* "$LOG_DIR/src/" 2>/dev/null || true
+            echo "Source files copied"
+          else
+            echo "No source files found"
+          fi
+
+          echo "Copying binaries from $IN/postgres/$COMPONENT/${COMPONENT}*"
+          if ls "$IN/postgres/$COMPONENT/${COMPONENT}"* 1> /dev/null 2>&1; then
+            cp "$IN/postgres/$COMPONENT/${COMPONENT}"* "$LOG_DIR/bin/" 2>/dev/null || true
+            echo "Binary files copied"
+          else
+            echo "No binary files found"
+          fi
+
+          # List collected artifacts
+          echo "=== COLLECTED ARTIFACTS ==="
+          ls -la "$LOG_DIR/"
+          ls -la "$LOG_DIR/src/" || echo "No source files"
+          ls -la "$LOG_DIR/bin/" || echo "No binary files"
+          echo "=========================="
+
+          if [[ $EXIT_CODE -ne 0 ]]; then
+            echo "Build failed. Artifacts collected for debugging."
+            exit $EXIT_CODE
+          fi
+
+      # Compress the log directory for artifact upload
+      - name: Compress log directory
+        if: always()
+        run: |
+          echo "Compressing log directory: $LOG_DIR"
+          cd "$(dirname "$LOG_DIR")"
+          tar -czf "${LOG_DIR}.tar.gz" "$(basename "$LOG_DIR")"
+          echo "Compressed archive created: ${LOG_DIR}.tar.gz"
+
+      # Upload the compressed log archive as an artifact
+      - name: Upload build log artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: current-build-log
+          path: ${{ env.LOG_DIR }}.tar.gz
+          if-no-files-found: warn
+
+      # Clean up historical build artifacts and temporary files
+      - name: Cleanup build artifacts
+        if: steps.build_to_devel.outcome == 'success'
+        continue-on-error: true
+        run: |
+          source ~/.bashrc
+
+          run_day=$(date +%j)
+          TARGET="$HIST/devel-$run_day"
+          echo "Cleaning up historical build directory: $TARGET"
+          if [ -d "$TARGET" ]; then
+            rm -rf "$TARGET"
+            echo "Removed $TARGET"
+          else
+            echo "No directory to clean"
+          fi
+
+          echo "Removing temporary log files..."
+          rm -rf "$LOG_DIR"
+          #rm -f "${LOG_DIR}.tar.gz" || true
+          echo "Cleanup completed"

--- a/.github/workflows/current-arm9-daily-build-devel.yml
+++ b/.github/workflows/current-arm9-daily-build-devel.yml
@@ -1,0 +1,271 @@
+name: Current Daily Build Devel - arm9
+
+# Define default environment variables for carrying defaults at the top for easy modification
+env:
+  DEFAULT_CLI_BRANCH: "REL25_01"      # Default CLI branch for scheduled runs
+  DEFAULT_MODE: "current"             # Always "current" for this workflow
+  DEFAULT_COMPONENT: "spock50"        # Default spock component name
+  DEFAULT_BRANCH: "main"              # Default branch for the spock component
+  DEFAULT_CLEAN_FLAG: "false"         # Default clean flag for scheduled runs
+
+# Triggers: Scheduled at 12:30 AM UTC and manual workflow dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      cli_branch:
+        description: "Select the CLI branch to build from (e.g. REL25_01)"
+        required: true
+        default: "REL25_01"
+        type: choice
+        options:
+          - REL25_01
+          - REL24_10
+
+      component:
+        description: "Spock in-dev component to additionally build (e.g. spock50)"
+        required: true
+        default: "spock50"
+        type: string
+
+      branch:
+        description: "Branch to use for spock component (e.g. main)"
+        required: true
+        default: "main"
+        type: string
+
+      prefix_selector:
+        description: "Choose S3 subdirectory strategy (default: MMDD, or custom)"
+        required: true
+        default: "default"
+        type: choice
+        options:
+          - default
+          - custom
+
+      custom_prefix:
+        description: "If 'custom' selected above, provide sub-directory name"
+        required: false
+        type: string
+
+      clean_prefix:
+        description: "Clean the repo sub-directory before copying packages"
+        required: false
+        type: choice
+        options:
+          - "false"
+          - "true"
+        default: "false"
+
+  schedule:
+    - cron: "30 0 * * *"  # 12:30 AM UTC, 8:30pm EST.. 1 hour after stable build at 11:30 PM UTC
+
+jobs:
+  build-current-arm9:
+    runs-on: [self-hosted, arm9]
+
+    steps:
+      # Resolve parameters (scheduled vs manual) and set up timestamped log directory
+      - name: Set build parameters and logfile
+        id: vars
+        run: |
+          source ~/.bashrc
+
+          echo "Resolving build parameters for CURRENT mode workflow..."
+
+          TODAY=$(date +%m%d)
+          RUNNER_NAME="${{ runner.name }}"
+
+          # Create timestamped log directory with mmddhhmmss format
+          TIMESTAMP=$(date +%m%d%H%M%S)
+          LOG_DIR="/tmp/current-build-$TIMESTAMP"
+          mkdir -p "$LOG_DIR"
+          echo "Created log directory: $LOG_DIR"
+
+          # Determine parameters based on trigger type
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            # Scheduled run: use defaults
+            PREFIX="$TODAY"
+            CLEAN_FLAG=""
+            SELECTED_CLI_BRANCH="${DEFAULT_CLI_BRANCH}"
+            COMPONENT="${DEFAULT_COMPONENT}"
+            BRANCH="${DEFAULT_BRANCH}"
+            echo "Scheduled run: Prefix=$PREFIX, Component=$COMPONENT, Branch=$BRANCH, Clean flag not set, CLI Branch=$SELECTED_CLI_BRANCH"
+          
+          else
+            # Manual run: process inputs
+            if [[ "${{ inputs.prefix_selector }}" == "default" ]]; then
+              PREFIX="$TODAY"
+              echo "Manual run: Using default prefix: $PREFIX"
+            else
+              # Custom prefix validation
+              if [[ "${{ inputs.prefix_selector }}" == "custom" && -z "${{ inputs.custom_prefix }}" ]]; then
+                echo "Error: Custom prefix selected but no input provided."
+                exit 1
+              fi
+              PREFIX="${{ inputs.custom_prefix }}"
+              echo "Manual run: Using custom prefix: $PREFIX"
+            fi
+
+            # Clean flag handling
+            if [[ "${{ inputs.clean_prefix }}" == "true" ]]; then
+              CLEAN_FLAG="-x"
+              echo "Clean flag is enabled"
+            else
+              CLEAN_FLAG=""
+              echo "Clean flag is disabled"
+            fi
+
+            SELECTED_CLI_BRANCH="${{ inputs.cli_branch }}"
+            COMPONENT="${{ inputs.component }}"
+            BRANCH="${{ inputs.branch }}"
+            echo "Manual run: Component=$COMPONENT, Branch=$BRANCH, CLI Branch=$SELECTED_CLI_BRANCH"
+          fi
+
+          # Set logfile path, matching stable workflow with "current" label
+          LOGFILE_NAME="build_to_devel_current-${RUNNER_NAME}-${TIMESTAMP}.log"
+          LOGFILE_PATH="$LOG_DIR/$LOGFILE_NAME"
+
+          # Export variables
+          echo "RUNNER_NAME=$RUNNER_NAME" >> $GITHUB_ENV
+          echo "MODE=${DEFAULT_MODE}" >> $GITHUB_ENV
+          echo "COMPONENT=$COMPONENT" >> $GITHUB_ENV
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+          echo "PREFIX=$PREFIX" >> $GITHUB_ENV
+          echo "CLEAN_FLAG=$CLEAN_FLAG" >> $GITHUB_ENV
+          echo "LOG_DIR=$LOG_DIR" >> $GITHUB_ENV
+          echo "LOGFILE_PATH=$LOGFILE_PATH" >> $GITHUB_ENV
+          echo "CLI_BRANCH=$SELECTED_CLI_BRANCH" >> $GITHUB_ENV
+
+          echo "Log file will be created at: $LOGFILE_PATH"
+
+      # Display the resolved configuration for debugging
+      - name: Show effective configuration
+        run: |
+          echo "=== CURRENT BUILD WORKFLOW CONFIGURATION ==="
+          echo "Runner: $RUNNER_NAME"
+          echo "Mode: $MODE"
+          echo "Component: $COMPONENT"
+          echo "Branch: $BRANCH"
+          echo "S3 Prefix: $PREFIX"
+          echo "Clean flag: $CLEAN_FLAG"
+          echo "Log directory: $LOG_DIR"
+          echo "Log file path: $LOGFILE_PATH"
+          echo "CLI branch: $CLI_BRANCH"
+          echo "=============================================="
+
+      # Verify environment details and switch to the specified CLI branch
+      - name: Confirm environment and switch CLI branch
+        id: cli_branch_checkout
+        run: |
+          source ~/.bashrc
+          echo "OS info:"
+          cat /etc/os-release
+          echo "Architecture:"
+          arch
+
+          echo "Navigating to CLI directory: $PGE"
+          cd $PGE
+
+          echo "Current branch and status:"
+          git branch
+          git status
+
+          echo "Stashing changes if any..."
+          git stash push -u -m "Temp stash for current build" || true
+
+          echo "Switching to branch: $CLI_BRANCH"
+          git checkout "$CLI_BRANCH" || true
+          echo "Branch checkout completed"
+
+      # Execute the build script and collect artifacts into src/ and bin/
+      - name: Run build and push to devel repo
+        id: build_to_devel
+        run: |
+          source ~/.bashrc
+
+          echo "Launching build script in CURRENT mode..."
+          cd $DEV
+
+          # Construct and run the build command
+          BUILD_CMD="./build_to_devel_2.sh -m $MODE -c $COMPONENT -b $BRANCH -d $PREFIX"
+          if [[ -n "$CLEAN_FLAG" ]]; then
+            BUILD_CMD="$BUILD_CMD $CLEAN_FLAG"
+          fi
+
+          echo "Executing: $BUILD_CMD"
+          $BUILD_CMD > "$LOGFILE_PATH" 2>&1
+          EXIT_CODE=$?
+
+          echo "Build finished with exit code: $EXIT_CODE"
+
+          # Collect artifacts into src/ and bin/
+          echo "Collecting source and binary artifacts..."
+          mkdir -p "$LOG_DIR/src" "$LOG_DIR/bin"
+
+          echo "Copying source files from $SOURCE/${COMPONENT}*"
+          if ls "$SOURCE/${COMPONENT}"* 1> /dev/null 2>&1; then
+            cp "$SOURCE/${COMPONENT}"* "$LOG_DIR/src/" 2>/dev/null || true
+            echo "Source files copied"
+          else
+            echo "No source files found"
+          fi
+
+          echo "Copying binaries from $IN/postgres/$COMPONENT/${COMPONENT}*"
+          if ls "$IN/postgres/$COMPONENT/${COMPONENT}"* 1> /dev/null 2>&1; then
+            cp "$IN/postgres/$COMPONENT/${COMPONENT}"* "$LOG_DIR/bin/" 2>/dev/null || true
+            echo "Binary files copied"
+          else
+            echo "No binary files found"
+          fi
+
+          # List collected artifacts
+          echo "=== COLLECTED ARTIFACTS ==="
+          ls -la "$LOG_DIR/"
+          ls -la "$LOG_DIR/src/" || echo "No source files"
+          ls -la "$LOG_DIR/bin/" || echo "No binary files"
+          echo "=========================="
+
+          if [[ $EXIT_CODE -ne 0 ]]; then
+            echo "Build failed. Artifacts collected for debugging."
+            exit $EXIT_CODE
+          fi
+
+      # Compress the log directory for artifact upload
+      - name: Compress log directory
+        if: always()
+        run: |
+          echo "Compressing log directory: $LOG_DIR"
+          cd "$(dirname "$LOG_DIR")"
+          tar -czf "${LOG_DIR}.tar.gz" "$(basename "$LOG_DIR")"
+          echo "Compressed archive created: ${LOG_DIR}.tar.gz"
+
+      # Upload the compressed log archive as an artifact
+      - name: Upload build log artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: current-build-log
+          path: ${{ env.LOG_DIR }}.tar.gz
+          if-no-files-found: warn
+
+      # Clean up historical build artifacts and temporary files
+      - name: Cleanup build artifacts
+        if: steps.build_to_devel.outcome == 'success'
+        continue-on-error: true
+        run: |
+          source ~/.bashrc
+
+          run_day=$(date +%j)
+          TARGET="$HIST/devel-$run_day"
+          echo "Cleaning up historical build directory: $TARGET"
+          if [ -d "$TARGET" ]; then
+            rm -rf "$TARGET"
+            echo "Removed $TARGET"
+          else
+            echo "No directory to clean"
+          fi
+
+          echo "Removing temporary log files..."
+          rm -rf "$LOG_DIR"
+          #rm -f "${LOG_DIR}.tar.gz" || true
+          echo "Cleanup completed"

--- a/.github/workflows/stable-amd8-daily-build-devel.yml
+++ b/.github/workflows/stable-amd8-daily-build-devel.yml
@@ -1,4 +1,4 @@
-name: Stable Daily Build Devel - arm9
+name: Stable Daily Build Devel - amd8
 
 env:
   DEFAULT_CLI_BRANCH: "REL25_01"
@@ -38,11 +38,11 @@ on:
         default: "false"
 
   schedule:
-    - cron: "30 23 * * *"  # 11:30PM UTC = 7:30PM EST
+    - cron: "0 23 * * *"  # 11PM UTC = 7PM EST
 
 jobs:
-  build-stable-arm9:
-    runs-on: [self-hosted, arm9]
+  build-stable-amd8:
+    runs-on: [self-hosted, amd8]
 
     steps:
       - name: Set build parameters and logfile
@@ -82,7 +82,7 @@ jobs:
             # Clean flag handling
             # If true is chosen in the clean dropdown, set the --clean flag
             if [[ "${{ inputs.clean_prefix }}" == "true" ]]; then
-              CLEAN_FLAG="--clean"
+              CLEAN_FLAG="-x"
               echo "Clean flag is enabled"
             else
               CLEAN_FLAG=""
@@ -146,10 +146,10 @@ jobs:
           echo "Launching daily build script..."
           cd $DEV
 
-          echo "Executing: ./build_to_devel.sh $PREFIX $CLEAN_FLAG"
-          ./build_to_devel.sh "$PREFIX" $CLEAN_FLAG > "$LOGFILE_PATH" 2>&1
+          echo "Executing: ./build_to_devel.sh -m stable -d $PREFIX $CLEAN_FLAG"
+          ./build_to_devel.sh -m stable -d "$PREFIX" $CLEAN_FLAG > "$LOGFILE_PATH" 2>&1
           EXIT_CODE=$?
-
+          
           echo "Build finished with exit code: $EXIT_CODE"
 
           if [[ $EXIT_CODE -ne 0 ]]; then
@@ -181,3 +181,5 @@ jobs:
           else
             echo "Directory $TARGET does not exist. Nothing to clean."
           fi
+
+

--- a/.github/workflows/stable-arm9-daily-build-devel.yml
+++ b/.github/workflows/stable-arm9-daily-build-devel.yml
@@ -1,4 +1,4 @@
-name: Stable Daily Build Devel - amd8
+name: Stable Daily Build Devel - arm9
 
 env:
   DEFAULT_CLI_BRANCH: "REL25_01"
@@ -38,11 +38,11 @@ on:
         default: "false"
 
   schedule:
-    - cron: "0 23 * * *"  # 11PM UTC = 7PM EST
+    - cron: "30 23 * * *"  # 11:30PM UTC = 7:30PM EST
 
 jobs:
-  build-stable-amd8:
-    runs-on: [self-hosted, amd8]
+  build-stable-arm9:
+    runs-on: [self-hosted, arm9]
 
     steps:
       - name: Set build parameters and logfile
@@ -80,9 +80,9 @@ jobs:
             fi
 
             # Clean flag handling
-            # If true is chosen in the clean dropdown, set the --clean flag
+            # If true is chosen in the clean dropdown, set the -x flag
             if [[ "${{ inputs.clean_prefix }}" == "true" ]]; then
-              CLEAN_FLAG="--clean"
+              CLEAN_FLAG="-x"
               echo "Clean flag is enabled"
             else
               CLEAN_FLAG=""
@@ -146,10 +146,10 @@ jobs:
           echo "Launching daily build script..."
           cd $DEV
 
-          echo "Executing: ./build_to_devel.sh $PREFIX $CLEAN_FLAG"
-          ./build_to_devel.sh "$PREFIX" $CLEAN_FLAG > "$LOGFILE_PATH" 2>&1
+          echo "Executing: ./build_to_devel.sh -m stable -d $PREFIX $CLEAN_FLAG"
+          ./build_to_devel.sh -m stable -d "$PREFIX" $CLEAN_FLAG > "$LOGFILE_PATH" 2>&1
           EXIT_CODE=$?
-          
+
           echo "Build finished with exit code: $EXIT_CODE"
 
           if [[ $EXIT_CODE -ne 0 ]]; then
@@ -181,5 +181,3 @@ jobs:
           else
             echo "Directory $TARGET does not exist. Nothing to clean."
           fi
-
-

--- a/env.sh
+++ b/env.sh
@@ -14,6 +14,10 @@ spock40V=4.0.10-1
 
 spock33V=3.3.6-1
 
+# removeComponentFromOut: Specifies the Spock component (e.g., spock50) to exclude from stable mode builds in make_tgz.sh.
+# This variable is ignored in current mode builds, which include all components.
+removeComponentFromOut=spock50
+
 lolorV=1.2-1
 snwflkV=2.2-1
 

--- a/make_tgz.sh
+++ b/make_tgz.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 cd "$(dirname "$0")"
 
+# Script to generate pgedge builds and the corresponding tgz bundles with mode-based customization.
+# Supports '-m MODE' switch for 'stable' (default) or 'current' modes.
+# In 'stable' mode, after generating builds, strips specified unstable components using 'removeComponentFromOut' from env.sh.
+# In 'current' mode, includes all components.
+
 TGZ_REPO="https://pgedge-download.s3.amazonaws.com/REPO"
 
 source env.sh
@@ -18,6 +23,33 @@ cmd () {
 
 }
 
+show_help() {
+  cat << EOF
+Usage: $0 [OPTIONS]
+  -m MODE         Build mode: 'stable' (default) or 'current'
+  -h              Show help
+
+Examples:
+  $0
+  $0 -m current
+EOF
+}
+
+MODE="stable"
+while getopts "m:h" opt; do
+  case $opt in
+    m) MODE="$OPTARG" ;;
+    h) show_help; exit 0 ;;
+    \?) show_help; exit 1 ;;
+  esac
+done
+# check that the mode passed is either stable or current
+if [[ "$MODE" != "stable" && "$MODE" != "current" ]]; then
+  echo "[ERROR] Invalid mode: $MODE"
+  show_help
+  exit 1
+fi
+
 ## MAINLINE ###################################
 
 vers="15 16 17"
@@ -26,6 +58,23 @@ for ver in ${vers}; do
   echo ""
   cmd "./build_all.sh $ver"
 done
+
+sleep 5
+# If mode is 'stable' and removeComponentFromOut has a value defined in env.sh,
+# strip the corresponding unstable component packages (e.g., spock50) from the build.
+# This ensures only stable components are included in the tgz bundle.
+# In 'current' mode, this step is skipped, preserving all stable and unstable components
+# Wildcards (*) in removeComponentFromOut are not supported.
+removeComponentFromOut="$(echo -n "$removeComponentFromOut" | xargs)"
+if [[ "$MODE" == "stable" && -n "$removeComponentFromOut" ]]; then
+  if [[ "$removeComponentFromOut" == *"*"* ]]; then
+    echo "[ERROR] removeComponentFromOut should not contain a wildcard (*). Skipping removal."
+  else
+    echo "[INFO] [STABLE MODE] Attempting to remove files matching: $OUT/${removeComponentFromOut}*.tgz"
+    removed_files=$(rm -vf "$OUT/${removeComponentFromOut}"*.* 2>&1 | wc -l)
+    echo "[INFO] Removed $removed_files files for $removeComponentFromOut."
+  fi
+fi
 
 ./bp.sh
 


### PR DESCRIPTION

### Add support for `current` daily builds with latest Spock

This PR sets up a parallel daily build mode (`current`) that includes the latest in-dev Spock (e.g. spock50) built from its main (or custom branch based on main), alongside our regular platform components. This gives us a clean and automated way to build, test latest Spock builds without impacting stable builds.


* **New workflows (amd8 and arm9):**

  * Run daily (8PM / 8:30PM EST) or manually with configurable options.
  * Include latest Spock build on top of stable platform set.
  * Builds pushed to:
    `s3://pgedge-devel/REPO/current/<label>` with a 7-day expiry.

* **Build script updates:**

  * `build_to_devel.sh` has been significantly enhanced to now support two modes:

    * `stable`: only stable components + latest CLI.
    * `current`: same as stable, but adds a Spock build from main/custom branch.
  * S3 path + lifecycle rules adjusted based on mode.

* **Other misc build script enhancements:**

  * `make_tgz.sh`: skips Spock in `stable` mode; adds spock in `current` mode.
  * `env.sh`: Introduces a new variable.
  * Renamed the original workflows and synced with new build script behavior.
