### PR TITLE
support --rm-data if custom data directory is in use

### DIFF
--- a/src/pgXX/remove-pgXX.py
+++ b/src/pgXX/remove-pgXX.py
@@ -15,5 +15,6 @@ if autostart == "on":
 isRM_DATA = os.getenv("isRM_DATA", "False")
 if isRM_DATA == "True":
     util.message("Removing 'data' directories at your request")
-    util.echo_cmd(f"sudo rm -r data/{pgver}")
+    data_dir = util.get_column("datadir", pgver)
+    util.echo_cmd(f"sudo rm -r {data_dir}")
     util.echo_cmd(f"sudo rm -r data/logs/{pgver}")


### PR DESCRIPTION
This enables `./pgedge remove pg16 --rm-data` to function when a custom data directory is in use via `pg_data`