### PR TITLE
Spock 5 integration in cli

### DIFF
--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -1292,6 +1292,36 @@ def init(cluster_name, install=True):
     if parsed_json is None:
         util.exit_message("Unable to load cluster JSON", 1)
 
+
+    latest = {"15": "15.13", "16": "16.9", "17": "17.5"}
+
+    # grab whatever the user put
+    requested = str(db_settings.get("pg_version", "")).strip()
+    if not requested:
+        util.exit_message("No pg_version specified in your JSON", 1)
+
+    # if they specified a minor version…
+    if "." in requested:
+
+        if requested not in latest.values():
+            util.exit_message(
+                "Spock 5.0 only supports PostgreSQL 15.13, 16.9 or 17.5 (got %s)" % requested,
+                1,
+            )
+        pg_version = requested
+    else:
+
+        if requested not in latest:
+            util.exit_message(
+                "Unsupported PostgreSQL major version '%s'. Spock 5.0 supports only %s"
+                % (requested, ", ".join(latest.keys())),
+                1,
+            )
+        pg_version = latest[requested]
+        db_settings["pg_version"] = pg_version
+    util.message(f"Using PostgreSQL version {pg_version} for Spock 5.0", "info")
+
+
     verbose = parsed_json.get("log_level", "info")
 
     all_nodes = nodes.copy()

--- a/cli/scripts/meta.py
+++ b/cli/scripts/meta.py
@@ -306,7 +306,6 @@ def get_default_spock(pgv):
         + pgv
         + "' \n"
         + "   AND component LIKE 'spock%'"
-        + "   AND version not LIKE '%devel%'"
     )
     try:
         c = con.cursor()

--- a/cli/scripts/setup.py
+++ b/cli/scripts/setup.py
@@ -87,16 +87,20 @@ setup.pgedge(User={User}, Passwd={Passwd}, dbName={dbName}, port={port}, pg_ver=
         dbName = setup_core.inputDbname()
 
     if pg_ver is None:
-       df_pg = util.get_default_pg()
-       if interactive:
-          pg_ver = setup_core.inputPgVer(df_pg)
-       else:
-          pg_ver = df_pg
+           df_pg = util.get_default_pg()
+           if interactive:
+            pg_ver = setup_core.inputPgVer(df_pg)
+           else:
+            pg_ver = df_pg
 
     pg_major, pg_minor = setup_core.parse_pg(pg_ver)
 
+    # Validate that if Spock ≥5 we're using PG 15.13+, 16.9+ or 17.5+
+    util.validate_spock_pg_compat(spock_ver, pg_ver)
+
     setup_core.check_pre_reqs(
         User, Passwd, dbName, port, pg_major, pg_minor, spock_ver, autostart)
+
 
     if interactive and yes is False:
         y_or_n = input("Do you want to continue? [Y/n] ")

--- a/cli/scripts/util.py
+++ b/cli/scripts/util.py
@@ -33,6 +33,7 @@ import tempfile
 import shutil
 import traceback
 import time
+import re
 import platform
 import subprocess
 import getpass
@@ -122,10 +123,6 @@ def get_default_spock(pgv):
        return(DEFAULT_SPOCK_17)
 
     return(DEFAULT_SPOCK)
-
-import re
-from semantic_version import Version
-from util import DEFAULT_PG, DEFAULT_SPOCK, DEFAULT_SPOCK_17
 
 def validate_spock_pg_compat(spock_ver: str = None, pg_ver: str = None) -> None:
     """

--- a/cli/scripts/util.py
+++ b/cli/scripts/util.py
@@ -8,8 +8,8 @@ MY_VERSION = "25.0.0"
 MY_CODENAME = ""
 
 DEFAULT_PG = "16"
-DEFAULT_SPOCK = "40"
-DEFAULT_SPOCK_17 = "40"
+DEFAULT_SPOCK = "50"
+DEFAULT_SPOCK_17 = "50"
 MY_CMD = os.getenv("MY_CMD", None)
 MY_HOME = os.getenv("MY_HOME", None)
 MY_LIBS = f"{MY_HOME}/hub/scripts/lib"

--- a/src/conf/versions.sql
+++ b/src/conf/versions.sql
@@ -335,9 +335,9 @@ INSERT INTO versions VALUES ('spock40-pg17', '4.0.8-1', 'amd, arm', 0, '20241218
 
 
 -- ## spock50 ###########################
-INSERT INTO releases VALUES ('spock50-pg15', 4, 'spock', 'Spock', '', 'test', '', 1, 'pgEdge Community', '', '');
-INSERT INTO releases VALUES ('spock50-pg16', 4, 'spock', 'Spock', '', 'test', '', 1, 'pgEdge Community', '', '');
-INSERT INTO releases VALUES ('spock50-pg17', 4, 'spock', 'Spock', '', 'test', '', 1, 'pgEdge Community', '', '');
+INSERT INTO releases VALUES ('spock50-pg15', 4, 'spock', 'Spock', '', 'prod', '', 1, 'pgEdge Community', '', '');
+INSERT INTO releases VALUES ('spock50-pg16', 4, 'spock', 'Spock', '', 'prod', '', 1, 'pgEdge Community', '', '');
+INSERT INTO releases VALUES ('spock50-pg17', 4, 'spock', 'Spock', '', 'prod', '', 1, 'pgEdge Community', '', '');
 
 INSERT INTO versions VALUES ('spock50-pg15', '5.0.0-devel1-1',   'amd, arm', 1, '20250521', 'pg15', '', '');
 INSERT INTO versions VALUES ('spock50-pg16', '5.0.0-devel1-1',   'amd, arm', 1, '20250521', 'pg16', '', '');

--- a/src/conf/versions.sql
+++ b/src/conf/versions.sql
@@ -74,11 +74,7 @@ CREATE TABLE extensions (
   preload_name   TEXT NOT NULL,
   default_conf   TEXT NOT NULL
 );
-INSERT INTO extensions VALUES ('spock33', 'spock', 1, 'spock',
-  'wal_level=logical | max_worker_processes=12 | max_replication_slots=16 |
-   max_wal_senders=16 | hot_standby_feedback=on | wal_sender_timeout=5s |
-   track_commit_timestamp=on | spock.conflict_resolution=last_update_wins | 
-   spock.save_resolutions=on | spock.conflict_log_level=DEBUG');
+
 INSERT INTO extensions VALUES ('spock40', 'spock', 1, 'spock',
   'wal_level=logical | max_worker_processes=12 | max_replication_slots=16 |
    max_wal_senders=16 | hot_standby_feedback=on | wal_sender_timeout=5s |
@@ -319,16 +315,6 @@ INSERT INTO versions VALUES ('snowflake-pg17', '2.2-1', 'amd, arm', 1, '20240626
 -- ## SPOCK (parent project) ############
 INSERT INTO projects VALUES ('spock', 'pge', 4, 0, '', 1, 'https://github.com/pgedge/spock/tags',
   'spock', 1, 'spock.png', 'Logical Rep w/ Conflict Resolution', 'https://github.com/pgedge/spock/', 'pg_spock, pgsspock, vulcan');
-
--- ## SPOCK33 ###########################
-INSERT INTO releases VALUES ('spock33-pg15', 4, 'spock', 'Spock', '', 'prod', '', 1, 'pgEdge Community', '', '');
-INSERT INTO releases VALUES ('spock33-pg16', 4, 'spock', 'Spock', '', 'prod', '', 1, 'pgEdge Community', '', '');
-
-INSERT INTO versions VALUES ('spock33-pg15', '3.3.6-1', 'amd, arm', 1, '20240820', 'pg15', '', '');
-INSERT INTO versions VALUES ('spock33-pg16', '3.3.6-1', 'amd, arm', 1, '20240820', 'pg16', '', '');
-
-INSERT INTO versions VALUES ('spock33-pg15', '3.3.5-1', 'amd, arm', 0, '20240607', 'pg15', '', '');
-INSERT INTO versions VALUES ('spock33-pg16', '3.3.5-1', 'amd, arm', 0, '20240607', 'pg16', '', '');
 
 -- ## SPOCK40 ###########################
 INSERT INTO releases VALUES ('spock40-pg15', 4, 'spock', 'Spock', '', 'prod', '', 1, 'pgEdge Community', '', '');


### PR DESCRIPTION
1. Spock 3 removed.
2. Spock 5 is the new **default** version.
3. Spock 5 now works with the specific minor versions of PostgreSQL 15, 16, and 17.
4. **Update Manager** now includes Spock 5 in its list.
5. The `init` command in the cluster module and the `setup` command in the setup module have been updated to work with Spock 5.
6. The `json-create` function now works with Spock 5.
