### PR TITLE
fix: db guc set supports quoted param

### DIFF
--- a/cli/scripts/db.py
+++ b/cli/scripts/db.py
@@ -8,6 +8,7 @@ import subprocess
 import json
 import util
 import fire
+import re
 
 def create(db=None, User=None, Passwd=None, pg=None, spock=None, help=False):
     """
@@ -109,12 +110,14 @@ def create(db=None, User=None, Passwd=None, pg=None, spock=None, help=False):
 
 def guc_set(guc_name, guc_value):
     """Set GUC."""
+
     pg_v, spock_v = util.get_pg_v()
     pg = pg_v[2:]
 
     nc = "./pgedge "
     ncb = nc + "pgbin " + str(pg) + " "
 
+    guc_value = re.sub(r'([\'\\])', r'\1\1', str(guc_value))
     cmd = f"ALTER SYSTEM SET {guc_name} = '{guc_value}'"
 
     rc1 = util.echo_cmd(ncb + '"psql -q -c \\"' + cmd + '\\" postgres"',False)    

--- a/cli/scripts/db.py
+++ b/cli/scripts/db.py
@@ -109,18 +109,20 @@ def create(db=None, User=None, Passwd=None, pg=None, spock=None, help=False):
 
 def guc_set(guc_name, guc_value):
     """Set GUC."""
-
     pg_v, spock_v = util.get_pg_v()
     pg = pg_v[2:]
 
     nc = "./pgedge "
     ncb = nc + "pgbin " + str(pg) + " "
 
-    cmd = f"ALTER SYSTEM SET {guc_name} = {guc_value}"
+    cmd = f"ALTER SYSTEM SET {guc_name} = '{guc_value}'"
+
     rc1 = util.echo_cmd(ncb + '"psql -q -c \\"' + cmd + '\\" postgres"',False)    
     cmd = f"SELECT pg_reload_conf()"
     rc2 = util.echo_cmd(ncb + '"psql -q -c \\"' + cmd + '\\" postgres"',False)
+    
     rcs = rc1 + rc2
+
     if rcs == 0:
         util.message(f"Set GUC {guc_name} to {guc_value}","info")
     else:


### PR DESCRIPTION
Adds an extra set of quotations to the guc_value portion of the ALTER SYSTEM SET SQL in order to support spaced, quoted guc values.

PLAT-44