### PR TITLE
json-create supports hostnames node config

### DIFF
--- a/cli/scripts/cluster.py
+++ b/cli/scripts/cluster.py
@@ -8,9 +8,10 @@ import time
 import sys
 import getpass
 from tabulate import tabulate # type: ignore
-from ipaddress import ip_address
+import socket
 import os
 import re
+
 
 BASE_DIR = "cluster"
 DEFAULT_REPO = "https://pgedge-download.s3.amazonaws.com/REPO"
@@ -1042,9 +1043,11 @@ def json_create(
             )
         try:
             if public_ip:
-                ip_address(public_ip)
+                socket.gethostbyname(public_ip)
+
             if private_ip:
-                ip_address(private_ip)
+                socket.gethostbyname(private_ip)
+
         except ValueError:
             validation_errors.append(
                 f"Invalid IP address provided for node {node.get('name')}."
@@ -1077,9 +1080,9 @@ def json_create(
                 )
             try:
                 if public_ip:
-                    ip_address(public_ip)
+                    socket.gethostbyname(public_ip)
                 if private_ip:
-                    ip_address(private_ip)
+                    socket.gethostbyname(private_ip)
             except ValueError:
                 validation_errors.append(
                     f"Invalid IP address provided for sub-node {sub_node.get('name')}."


### PR DESCRIPTION
json-create allows creation of a node or subnode  with either ip address or hostname through the use of socket.gethostbyname

PLAT-131