### PR TITLE
Support spaces in `--datadir` paths

### DIFF
--- a/cli/scripts/setup.py
+++ b/cli/scripts/setup.py
@@ -104,7 +104,7 @@ setup.pgedge(User={User}, Passwd={Passwd}, dbName={dbName}, port={port}, pg_data
             util.exit_message(
                 "pg_data cannot be set as relative path. Please specify absolute path instead"
             )
-        pg_init_options = f"--datadir={pg_data}"
+        pg_init_options = f'--datadir="{pg_data}"'
 
     setup_core.check_pre_reqs(
         User, Passwd, dbName, port, pg_data, pg_major, pg_minor, spock_ver, autostart)

--- a/src/pgXX/init-pgXX.py
+++ b/src/pgXX/init-pgXX.py
@@ -62,7 +62,6 @@ if not os.path.isdir(data_root):
 if args.datadir == "":
     pg_data = os.path.join(data_root, pgver)
 else:
-
     pg_data = args.datadir.replace(r'\ ', ' ')
 
 if not os.path.isdir(pg_data):


### PR DESCRIPTION
1. * **Normalize `--datadir` input** by replacing all `\ ` sequences with actual spaces
2. * **Assign cleaned path** to `pg_data` before directory creation and downstream use
3. * **Ensure** `initdb`, SSL cert generation, `pg_hba.conf` copy, and `pg_ctl` all target the real filesystem path
4. * **Prevent errors** when users pass paths like `/home/moiz/pgdir_test\ 6` on the CLI
