### PR TITLE
[BR-158]: Introduce spock60 builds in CLI

### DIFF
--- a/.github/workflows/current-amd8-daily-build-devel.yml
+++ b/.github/workflows/current-amd8-daily-build-devel.yml
@@ -4,7 +4,7 @@ name: Current Daily Build Devel - amd8
 env:
   DEFAULT_CLI_BRANCH: "main"          # Default CLI branch for scheduled runs
   DEFAULT_MODE: "current"             # Always "current" for this workflow
-  DEFAULT_COMPONENT: "spock50"        # Default spock component name
+  DEFAULT_COMPONENT: "spock60"        # Default spock component name
   DEFAULT_BRANCH: "main"              # Default branch for the spock component
   DEFAULT_CLEAN_FLAG: "false"         # Default clean flag for scheduled runs
 
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       cli_branch:
-        description: "Select the CLI branch to build from (e.g. v25_STABLE)"
+        description: "Select the CLI branch to build from (e.g. main)"
         required: true
         default: "main"
         type: choice
@@ -23,9 +23,9 @@ on:
           - REL24_10
 
       component:
-        description: "Spock in-dev component to additionally build (e.g. spock50)"
+        description: "Spock in-dev component to additionally build (e.g. spock60)"
         required: true
-        default: "spock50"
+        default: "spock60"
         type: string
 
       branch:

--- a/.github/workflows/current-arm9-daily-build-devel.yml
+++ b/.github/workflows/current-arm9-daily-build-devel.yml
@@ -4,7 +4,7 @@ name: Current Daily Build Devel - arm9
 env:
   DEFAULT_CLI_BRANCH: "main"          # Default CLI branch for scheduled runs
   DEFAULT_MODE: "current"             # Always "current" for this workflow
-  DEFAULT_COMPONENT: "spock50"        # Default spock component name
+  DEFAULT_COMPONENT: "spock60"        # Default spock component name
   DEFAULT_BRANCH: "main"              # Default branch for the spock component
   DEFAULT_CLEAN_FLAG: "false"         # Default clean flag for scheduled runs
 
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       cli_branch:
-        description: "Select the CLI branch to build from (e.g. v25_STABLE)"
+        description: "Select the CLI branch to build from (e.g. main)"
         required: true
         default: "main"
         type: choice
@@ -23,9 +23,9 @@ on:
           - REL24_10
 
       component:
-        description: "Spock in-dev component to additionally build (e.g. spock50)"
+        description: "Spock in-dev component to additionally build (e.g. spock60)"
         required: true
-        default: "spock50"
+        default: "spock60"
         type: string
 
       branch:

--- a/build.sh
+++ b/build.sh
@@ -358,18 +358,21 @@ initPG () {
     initC "audit-pg$pgM"      "audit"      "$audit17V"   "$outPlat" "postgres/audit"     "" "" "nil"
     initC "hintplan-pg$pgM"   "hintplan"   "$hint17V"    "$outPlat" "postgres/hintplan"  "" "" "nil"
     initC "spock50-pg$pgM"    "spock50"    "$spock50V"   "$outPlat" "postgres/spock50"   "" "" "nil"
+    initC "spock60-pg$pgM"    "spock60"    "$spock60V"   "$outPlat" "postgres/spock60"   "" "" "nil"
   fi
 
   if [ "$pgM" == "16" ]; then
     initC "audit-pg$pgM"      "audit"      "$audit16V"   "$outPlat" "postgres/audit"     "" "" "nil"
     initC "hintplan-pg$pgM"   "hintplan"   "$hint16V"    "$outPlat" "postgres/hintplan"  "" "" "nil"
     initC "spock50-pg$pgM"    "spock50"    "$spock50V"   "$outPlat" "postgres/spock50"   "" "" "nil"
+    initC "spock60-pg$pgM"    "spock60"    "$spock60V"   "$outPlat" "postgres/spock60"   "" "" "nil"
   fi
 
   if [ "$pgM" == "15" ]; then
     initC "audit-pg$pgM"      "audit"      "$audit15V"   "$outPlat" "postgres/audit"     "" "" "nil"
     initC "hintplan-pg$pgM"   "hintplan"   "$hint15V"    "$outPlat" "postgres/hintplan"  "" "" "nil"
     initC "spock50-pg$pgM"    "spock50"    "$spock50V"   "$outPlat" "postgres/spock50"   "" "" "nil"
+    initC "spock60-pg$pgM"    "spock60"    "$spock60V"   "$outPlat" "postgres/spock60"   "" "" "nil"
   fi
 
   if [ "$pgM" == "15" ] || [ "$pgM" == "16" ] || [ "$pgM" == "17" ]; then

--- a/env.sh
+++ b/env.sh
@@ -8,6 +8,8 @@ bundle=pgedge
 api=pgedge
 ctlibsV=1.7
 
+spock60V=6.0.0-devel-1
+
 spock50V=5.0.0-1
 
 spock40V=4.0.10-1

--- a/src/conf/versions.sql
+++ b/src/conf/versions.sql
@@ -84,6 +84,11 @@ INSERT INTO extensions VALUES ('spock50', 'spock', 1, 'spock',
    max_wal_senders=16 | hot_standby_feedback=on | wal_sender_timeout=5s |
    track_commit_timestamp=on | spock.conflict_resolution=last_update_wins | 
    spock.save_resolutions=on | spock.conflict_log_level=DEBUG');
+INSERT INTO extensions VALUES ('spock60', 'spock', 1, 'spock',
+  'wal_level=logical | max_worker_processes=12 | max_replication_slots=16 |
+   max_wal_senders=16 | hot_standby_feedback=on | wal_sender_timeout=5s |
+   track_commit_timestamp=on | spock.conflict_resolution=last_update_wins | 
+   spock.save_resolutions=on | spock.conflict_log_level=DEBUG');
 INSERT INTO extensions VALUES ('lolor',     'lolor',     0, '',          '');
 INSERT INTO extensions VALUES ('postgis',   'postgis',   1, 'postgis-3', '');
 INSERT INTO extensions VALUES ('setuser',   'set_user',  1, 'set_user',  '');
@@ -341,6 +346,15 @@ INSERT INTO releases VALUES ('spock50-pg17', 4, 'spock', 'Spock', '', 'prod', ''
 INSERT INTO versions VALUES ('spock50-pg15', '5.0.0-1',   'amd, arm', 1, '20250715', 'pg15', '', '');
 INSERT INTO versions VALUES ('spock50-pg16', '5.0.0-1',   'amd, arm', 1, '20250715', 'pg16', '', '');
 INSERT INTO versions VALUES ('spock50-pg17', '5.0.0-1',   'amd, arm', 1, '20250715', 'pg17', '', '');
+
+-- ## spock60 ###########################
+INSERT INTO releases VALUES ('spock60-pg15', 4, 'spock', 'Spock', '', 'test', '', 1, 'pgEdge Community', '', '');
+INSERT INTO releases VALUES ('spock60-pg16', 4, 'spock', 'Spock', '', 'test', '', 1, 'pgEdge Community', '', '');
+INSERT INTO releases VALUES ('spock60-pg17', 4, 'spock', 'Spock', '', 'test', '', 1, 'pgEdge Community', '', '');
+
+INSERT INTO versions VALUES ('spock60-pg15', '6.0.0-devel-1',   'amd, arm', 1, '20250801', 'pg15', '', '');
+INSERT INTO versions VALUES ('spock60-pg16', '6.0.0-devel-1',   'amd, arm', 1, '20250801', 'pg16', '', '');
+INSERT INTO versions VALUES ('spock60-pg17', '6.0.0-devel-1',   'amd, arm', 1, '20250801', 'pg17', '', '');
 
 -- ## LOLOR #############################
 INSERT INTO projects VALUES ('lolor', 'pge', 4, 0, '', 1, 'https://github.com/pgedge/lolor/tags',


### PR DESCRIPTION
Build script changes to produce spock60 builds from the main branch. 
Updated versioning (6.0.0-devel) and metadata.
Updated 'current' builds workflow to now produce spock60 from main. 
Although, spock60 is hidden in the um list output, it can be installed in the current builds (only) by passing --spock_ver=6.0.0 in the pgedge setup command.