### PR TITLE
ensure pg_version is string

### DIFF
--- a/cli/scripts/contrib/localhost.py
+++ b/cli/scripts/contrib/localhost.py
@@ -145,7 +145,7 @@ def cluster_create(
     """
 
     util.message(f"localhost.cluster_create({cluster_name}, {num_nodes}, {pg}, {port1}, {User}, {Passwd}, {db})", "debug")
-
+    pg = str(pg)
     util.message("# verifying passwordless ssh...")
     if util.is_password_less_ssh():
         pass


### PR DESCRIPTION
Normalized pg parameter to string early in cluster_create() and create_local_json() to prevent TypeError when concatenating paths in cluster.load_json()